### PR TITLE
fix(1.6): remove use keyword and use the namespace directly at the instantiation of the object

### DIFF
--- a/ps_eventbus.php
+++ b/ps_eventbus.php
@@ -24,11 +24,10 @@
  *  International Registered Trademark & Property of PrestaShop SA
  */
 
-use Symfony\Component\Dotenv\Dotenv;
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }
+
 require_once __DIR__ . '/vendor/autoload.php';
 
 class Ps_eventbus extends Module
@@ -158,7 +157,7 @@ class Ps_eventbus extends Module
      */
     private function loadEnv()
     {
-        $dotEnv = new Dotenv();
+        $dotEnv = new Symfony\Component\Dotenv\Dotenv();
 
         $dotEnv->load(_PS_MODULE_DIR_ . 'ps_eventbus/.env.dist');
 


### PR DESCRIPTION
On PrestaShop 1.6 we cannot use the "use" keyword in the main class. We need to provide the namespace directly at the instantiation of the class.