### PR TITLE
Remove uneeded properties from main class

### DIFF
--- a/ps_eventbus.php
+++ b/ps_eventbus.php
@@ -39,51 +39,6 @@ class Ps_eventbus extends Module
     /**
      * @var string
      */
-    public $author;
-
-    /**
-     * @var bool
-     */
-    public $bootstrap;
-
-    /**
-     * @var int
-     */
-    public $need_instance;
-
-    /**
-     * @var string
-     */
-    public $description;
-
-    /**
-     * @var string
-     */
-    public $confirmUninstall;
-
-    /**
-     * @var string
-     */
-    public $displayName;
-
-    /**
-     * @var string
-     */
-    public $name;
-
-    /**
-     * @var array
-     */
-    public $ps_versions_compliancy;
-
-    /**
-     * @var string
-     */
-    public $tab;
-
-    /**
-     * @var string
-     */
     const VERSION = 'x.y.z';
 
     /**


### PR DESCRIPTION
Some properties are already defined in the Module class of the core.
It seems they are also defined in the ps_eventbus main class to fix some PHPStan errors about misleading types, but this issue has been fixed a few months ago with https://github.com/PrestaShop/php-dev-tools/pull/35.

On the other hand, keeping these properties may trigger errors in some case, as reported by @boubkerbribri on QA automatic tests. This PR fixes it.

![image](https://user-images.githubusercontent.com/6768917/116438493-67f1a980-a846-11eb-9bc1-02bd429802b7.png)
