### PR TITLE
Fix overriden computed weight

### DIFF
--- a/src/Repository/ProductRepository.php
+++ b/src/Repository/ProductRepository.php
@@ -336,7 +336,7 @@ class ProductRepository
             p.date_add as created_at, p.date_upd as updated_at,
             p.available_for_order, p.available_date, p.cache_is_pack as is_bundle, p.is_virtual');
 
-        $query->select('p.width, p.height, p.depth, p.weight, p.additional_delivery_times, p.additional_shipping_cost');
+        $query->select('p.width, p.height, p.depth, p.additional_delivery_times, p.additional_shipping_cost');
         $query->select('pl.delivery_in_stock, pl.delivery_out_stock');
 
         if (version_compare(_PS_VERSION_, '1.7', '>=')) {


### PR DESCRIPTION
When dealing products with combinations, the sent weight was still the product's one without the `impact` from the attribute.

This was caused by 2 columns sharing the same name.

On the following screenshot, you'll see the column `weight` displayed 2 times. The first one is expected and contains the calculation from the database. The second one is only the product's weight.

![Capture d’écran du 2022-03-03 12-25-10](https://user-images.githubusercontent.com/6768917/156580911-ab3b7311-f4d7-4895-b9c5-8baaad0c4f90.png)

