### PR TITLE
Use product combination images when at least one has ben chosen

### DIFF
--- a/src/Decorator/ProductDecorator.php
+++ b/src/Decorator/ProductDecorator.php
@@ -310,6 +310,7 @@ class ProductDecorator
                 }
             }
 
+            // Product is without attributes -> get product images
             if ($product['id_attribute'] === '0') {
                 $productImageIds = $this->arrayFormatter->formatValueArray($productImages, 'id_image');
             } else {
@@ -317,7 +318,15 @@ class ProductDecorator
                     return $image['id_product_attribute'] === $product['id_attribute'];
                 });
 
-                $productImageIds = $this->arrayFormatter->formatValueArray($productAttributeImages, 'id_image');
+                // If combination has some pictures -> the first one is the cover
+                if (count($productAttributeImages)) {
+                    $productImageIds = $this->arrayFormatter->formatValueArray($productAttributeImages, 'id_image');
+                    $coverImageId = reset($productImageIds);
+                }
+                // Fallback on cover & images of the product when no pictures are chosen
+                else {
+                    $productImageIds = $this->arrayFormatter->formatValueArray($productImages, 'id_image');
+                }
             }
 
             $productImageIds = array_diff($productImageIds, [$coverImageId]);

--- a/tests/unit/ProductDecoratorTest.php
+++ b/tests/unit/ProductDecoratorTest.php
@@ -165,4 +165,212 @@ class ProductDecoratorTest extends BaseTestCase
         $this->assertInternalType('float', $products[0]['price_tax_excl']);
         $this->assertInternalType('float', $products[0]['price_tax_incl']);
     }
+
+    /**
+     * @Stories("product decorator")
+     * @Title("testDecorateProducts")
+     */
+    public function testDecorateProductsWithCombination()
+    {
+        $products = [
+            [
+                'id_product' => '1',
+                'id_attribute' => '3',
+                'name' => 'Hummingbird printed t-shirt',
+                'description' => '<p>SOME HTML</p>',
+                'description_short' => '<p>SOME HTML</p>',
+                'link_rewrite' => 'hummingbird-printed-t-shirt',
+                'iso_code' => 'lt',
+                'default_category' => 'Men',
+                'id_category_default' => '4',
+                'reference' => 'demo_1',
+                'upc' => '',
+                'ean' => '',
+                'isbn' => '',
+                'condition' => 'new',
+                'visibility' => 'both',
+                'active' => true,
+                'quantity' => '300',
+                'manufacturer' => 'Studio Design',
+                'weight' => '10.0',
+                'price_tax_excl' => '23.9',
+                'created_at' => '2020-08-19 08:29:12',
+                'updated_at' => '2020-09-22 10:02:45',
+                'attributes' => 'Dydis:M;Spalva:Balta',
+                'features' => 'Savybė:Trumpos rankovės;Sudėtis:Medvilnė',
+                'images' => '1:1;2:0',
+                'attribute_images' => '1;2;3',
+                'is_default_attribute' => '1',
+                'available_for_order' => '1',
+                'available_date' => '0000-00-00',
+                'is_bundle' => '0',
+                'is_virtual' => '1',
+            ],
+            [
+                'id_product' => '1',
+                'id_attribute' => '4',
+                'name' => 'Hummingbird printed t-shirt',
+                'description' => '<p>SOME HTML</p>',
+                'description_short' => '<p>SOME HTML</p>',
+                'link_rewrite' => 'hummingbird-printed-t-shirt',
+                'iso_code' => 'lt',
+                'default_category' => 'Men',
+                'id_category_default' => '4',
+                'reference' => 'demo_1',
+                'upc' => '',
+                'ean' => '',
+                'isbn' => '',
+                'condition' => 'new',
+                'visibility' => 'both',
+                'active' => true,
+                'quantity' => '300',
+                'manufacturer' => 'Studio Design',
+                'weight' => '10.0',
+                'price_tax_excl' => '23.9',
+                'created_at' => '2020-08-19 08:29:12',
+                'updated_at' => '2020-09-22 10:02:45',
+                'attributes' => 'Dydis:M;Spalva:Balta',
+                'features' => 'Savybė:Trumpos rankovės;Sudėtis:Medvilnė',
+                'images' => '1:1;2:0',
+                'attribute_images' => '1',
+                'is_default_attribute' => '1',
+                'available_for_order' => '1',
+                'available_date' => '0000-00-00',
+                'is_bundle' => '0',
+                'is_virtual' => '1',
+            ],
+            [
+                'id_product' => '1',
+                'id_attribute' => '5',
+                'name' => 'Hummingbird printed t-shirt',
+                'description' => '<p>SOME HTML</p>',
+                'description_short' => '<p>SOME HTML</p>',
+                'link_rewrite' => 'hummingbird-printed-t-shirt',
+                'iso_code' => 'lt',
+                'default_category' => 'Men',
+                'id_category_default' => '4',
+                'reference' => 'demo_1',
+                'upc' => '',
+                'ean' => '',
+                'isbn' => '',
+                'condition' => 'new',
+                'visibility' => 'both',
+                'active' => true,
+                'quantity' => '300',
+                'manufacturer' => 'Studio Design',
+                'weight' => '10.0',
+                'price_tax_excl' => '23.9',
+                'created_at' => '2020-08-19 08:29:12',
+                'updated_at' => '2020-09-22 10:02:45',
+                'attributes' => 'Dydis:M;Spalva:Balta',
+                'features' => 'Savybė:Trumpos rankovės;Sudėtis:Medvilnė',
+                'images' => '1:1;2:0',
+                'attribute_images' => '1',
+                'is_default_attribute' => '1',
+                'available_for_order' => '1',
+                'available_date' => '0000-00-00',
+                'is_bundle' => '0',
+                'is_virtual' => '1',
+            ],
+        ];
+
+        $categories = [
+            'category_path' => 'Root > Home > Clothes > Men',
+            'category_id_path' => '1 > 2 > 3 > 4',
+        ];
+
+        $contextMock = $this->createMock(Context::class);
+        $linkMock = $this->createMock(Link::class);
+        $linkMock->method('getProductLink')->willReturn('https://test.link/1-0-product.html');
+        $linkMock->method('getImageLink')->willReturnCallback(
+            function ($linkRewrite, $id) {
+                return "https://test.link/1-${id}-product.jpg";
+            });
+
+        $shopMock = $this->createMock(Shop::class);
+        $shopMock->id = 1;
+
+        $contextMock->link = $linkMock;
+        $contextMock->shop = $shopMock;
+
+        $languageRepository = $this->createMock(LanguageRepository::class);
+        $languageRepository->method('getLanguageIdByIsoCode')->willReturn(1);
+        $productRepository = $this->createMock(ProductRepository::class);
+        $productRepository->method('getProductImages')->willReturn([
+            [
+                'id_product' => '1',
+                'id_image' => '11358',
+                'cover' => '0',
+            ],
+            [
+                'id_product' => '1',
+                'id_image' => '11359',
+                'cover' => '0',
+            ],
+            [
+                'id_product' => '1',
+                'id_image' => '11360',
+                'cover' => '0',
+            ],
+            [
+                'id_product' => '1',
+                'id_image' => '14136',
+                'cover' => '0',
+            ],
+            [
+                'id_product' => '1',
+                'id_image' => '11357',
+                'cover' => '1',
+            ],
+        ]);
+        $productRepository->method('getAttributeImages')->willReturn([
+            [
+                'id_product_attribute' => '3',
+                'id_image' => '11359',
+            ],
+            [
+                'id_product_attribute' => '3',
+                'id_image' => '11360',
+            ],
+            [
+                'id_product_attribute' => '4',
+                'id_image' => '14136',
+            ],
+        ]);
+        $categoryRepository = $this->createMock(CategoryRepository::class);
+        $categoryRepository->method('getCategoryPaths')->willReturn($categories);
+        $bundleRepository = $this->createMock(BundleRepository::class);
+
+        $arrayFormatter = new ArrayFormatter();
+
+        $productDecorator = new ProductDecorator($contextMock, $languageRepository, $productRepository, $categoryRepository, $arrayFormatter, $bundleRepository);
+        $productDecorator->decorateProducts($products, 'en', 1);
+
+        $this->assertEquals(
+            'https://test.link/1-11360-product.jpg',
+            $products[0]['images']
+        );
+        $this->assertEquals(
+            'https://test.link/1-11359-product.jpg',
+            $products[0]['cover']
+        );
+
+        $this->assertEquals(
+            '',
+            $products[1]['images']
+        );
+        $this->assertEquals(
+            'https://test.link/1-14136-product.jpg',
+            $products[1]['cover']
+        );
+
+        $this->assertEquals(
+            'https://test.link/1-11358-product.jpg;https://test.link/1-11359-product.jpg;https://test.link/1-11360-product.jpg;https://test.link/1-14136-product.jpg',
+            $products[2]['images']
+        );
+        $this->assertEquals(
+            'https://test.link/1-11357-product.jpg',
+            $products[2]['cover']
+        );
+    }
 }


### PR DESCRIPTION
Allow product combination to have their own image when at least one has been assigned on the product sheet.

Result of synchronisation with a shop having this change:
![image](https://user-images.githubusercontent.com/6768917/156783978-c2a19225-069e-46a8-8c9b-df32fe19e521.png)
