### PR TITLE
Handle empty strings as NULL for attributes

### DIFF
--- a/src/Repository/ProductRepository.php
+++ b/src/Repository/ProductRepository.php
@@ -307,8 +307,8 @@ class ProductRepository
     {
         $query->select('p.id_product, IFNULL(pas.id_product_attribute, 0) as id_attribute, pas.default_on as is_default_attribute,
             pl.name, pl.description, pl.description_short, pl.link_rewrite, cl.name as default_category,
-            ps.id_category_default, IFNULL(pa.reference, p.reference) as reference, IFNULL(pa.upc, p.upc) as upc,
-            IFNULL(pa.ean13, p.ean13) as ean, ps.condition, ps.visibility, ps.active, sa.quantity, m.name as manufacturer,
+            ps.id_category_default, IFNULL(NULLIF(pa.reference, ""), p.reference) as reference, IFNULL(NULLIF(pa.upc, ""), p.upc) as upc,
+            IFNULL(NULLIF(pa.ean13, ""), p.ean13) as ean, ps.condition, ps.visibility, ps.active, sa.quantity, m.name as manufacturer,
             (p.weight + IFNULL(pas.weight, 0)) as weight, (ps.price + IFNULL(pas.price, 0)) as price_tax_excl,
             p.date_add as created_at, p.date_upd as updated_at,
             p.available_for_order, p.available_date, p.cache_is_pack as is_bundle, p.is_virtual,
@@ -323,7 +323,7 @@ class ProductRepository
         $query->select('pl.delivery_in_stock, pl.delivery_out_stock');
 
         if (version_compare(_PS_VERSION_, '1.7', '>=')) {
-            $query->select('IFNULL(pa.isbn, p.isbn) as isbn');
+            $query->select('IFNULL(NULLIF(pa.isbn, ""), p.isbn) as isbn');
         }
     }
 }


### PR DESCRIPTION
When we create combinations on PrestaShop, their default values for EAN, ISBN and references are empty strings.

On the SQL request made by the module, only Null values are taken in account to fallback on the global value.

On the following screenshots:
- the first element is a combination of attributes (no ISBN for the attribute, so the product ISBN value is expected to be returned).
- the second element is a basic product with a ISBN.

ISBNs can be found at the end of each element in the array.

Before the PR:
![Capture d’écran du 2022-05-19 11-48-18](https://user-images.githubusercontent.com/6768917/169277938-b048aa6a-3aa5-4d9a-8fb5-29e1e1dd5047.png)

With this PR:
![Capture d’écran du 2022-05-19 11-50-19](https://user-images.githubusercontent.com/6768917/169277958-ec413e47-e92b-4130-a126-17a578071dfc.png)

