### PR TITLE
Fixes #EB-517

### DIFF
--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -67,14 +67,13 @@ class OrderRepository
      */
     public function getRemainingOrderCount($offset, $shopId)
     {
-        $query = new \DbQuery();
+        $orders = $this->getOrders($offset, 1, $shopId);
 
-        $query->select('COUNT(o.id_order) as count')
-            ->from(self::ORDERS_TABLE, 'o')
-            ->where('o.id_shop = ' . (int) $shopId)
-            ->limit(1, $offset);
+        if (!is_array($orders) || empty($orders)) {
+            return 0;
+        }
 
-        return (int) $this->db->getValue($query);
+        return count($orders);
     }
 
     /**


### PR DESCRIPTION
On a fullsync mode, the second call was producing this:

```
❯ curl -i 'https://8c85-88-162-75-65.eu.ngrok.io/index.php?fc=module&module=ps_eventbus&controller=apiOrders&job_id=0a47433a1b3ac3e8cd89c91b58ef801e840e2958&limit=50'
HTTP/2 500 
cache-control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
content-type: application/json;charset=utf-8
date: Wed, 18 Jan 2023 20:52:55 GMT
ngrok-trace-id: 7aeb437a5bb99d1da0d0998159bf119f
server: Apache/2.4.54 (Debian)
set-cookie: PrestaShop-d691e2ea23ff4e041cab61f0bee01f0a=def50200a9bbab6608323c6511b7c8bc9c57e2b84445fcbd98a501986787ed4ea56e41426bfa9a0cd4b7177491c3e832f461ded9b6397697b57368a2ba3902cdfdadaa52a031353e20574db8a42c44c3afb15094366a000a1b7e77877e66a7e4a2a45234530c5caf29b018e08dc322cccb6216114944e9c61262102fe5fe6f2f5e880060b66b6badf48c7767aacc5d0452034cab5191f6cadcd7702547a164842475d9bdd5ec055496f4337248c427bc91bf74bcede7cacd28a6e6ef9ceed00f429b80027da1; expires=Tue, 07-Feb-2023 20:52:55 GMT; Max-Age=1727999; path=/; domain=8c85-88-162-75-65.eu.ngrok.io; secure; HttpOnly; SameSite=Lax
content-length: 280
{"object_type":"orders","status":false,"httpCode":42000,"message":"SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'LIMIT 1' at line 4"}
```