### PR TITLE
Delete themes and modules from required consents

### DIFF
--- a/src/Repository/OrderDetailsRepository.php
+++ b/src/Repository/OrderDetailsRepository.php
@@ -53,7 +53,7 @@ class OrderDetailsRepository
         $query->select('od.id_order_detail, od.id_order, od.product_id, od.product_attribute_id,
          od.product_quantity, od.unit_price_tax_incl, od.unit_price_tax_excl, SUM(osd.total_price_tax_incl) as refund,
           SUM(osd.total_price_tax_excl) as refund_tax_excl, c.iso_code as currency, ps.id_category_default as category,
-          l.iso_code, o.conversion_rate as conversion_rate, o.date_add as created_at, o.date_upd as updated_at')
+          l.iso_code, o.conversion_rate as conversion_rate')
             ->leftJoin('order_slip_detail', 'osd', 'od.id_order_detail = osd.id_order_detail')
             ->leftJoin('product_shop', 'ps', 'od.product_id = ps.id_product AND ps.id_shop = ' . (int) $shopId)
             ->innerJoin('orders', 'o', 'od.id_order = o.id_order')

--- a/src/Repository/ProductSupplierRepository.php
+++ b/src/Repository/ProductSupplierRepository.php
@@ -20,8 +20,7 @@ class ProductSupplierRepository
     public function getBaseQuery()
     {
         $query = new \DbQuery();
-        $query->from('product_supplier', 'ps')
-        ->innerJoin('product', 'p', 'p.id_product = ps.id_product');
+        $query->from('product_supplier', 'ps');
 
         return $query;
     }
@@ -86,6 +85,6 @@ class ProductSupplierRepository
     private function addSelectParameters(\DbQuery $query)
     {
         $query->select('ps.id_product_supplier, ps.id_product, ps.id_product_attribute, ps.id_supplier, ps.product_supplier_reference,
-        ps.product_supplier_price_te, ps.id_currency, p.date_add AS created_at, p.date_upd as updated_at');
+        ps.product_supplier_price_te, ps.id_currency');
     }
 }

--- a/src/Repository/StockRepository.php
+++ b/src/Repository/StockRepository.php
@@ -29,8 +29,8 @@ class StockRepository
     {
         $query = new \DbQuery();
         $query->from('stock_available', 'sa')
-        ->innerJoin('product', 'p', 'p.id_product = sa.id_product')
-        ->where('sa.id_shop = ' . (int) $shopId);
+            ->innerJoin('product', 'p', 'p.id_product = sa.id_product')
+            ->where('sa.id_shop = ' . (int) $shopId);
 
         return $query;
     }
@@ -101,7 +101,6 @@ class StockRepository
     private function addSelectParameters(\DbQuery $query)
     {
         $query->select('sa.id_stock_available, sa.id_product, sa.id_product_attribute, sa.id_shop, sa.id_shop_group,
-        sa.quantity, sa.physical_quantity, sa.reserved_quantity, sa.depends_on_stock, sa.out_of_stock, sa.location,
-        p.date_add AS created_at, p.date_upd as updated_at');
+        sa.quantity, sa.physical_quantity, sa.reserved_quantity, sa.depends_on_stock, sa.out_of_stock, sa.location');
     }
 }

--- a/src/Service/PresenterService.php
+++ b/src/Service/PresenterService.php
@@ -73,23 +73,6 @@ class PresenterService
     }
 
     /**
-     * @param array $consents
-     *
-     * @return array
-     */
-    private function enforceMandatoryConsents($consents)
-    {
-        $mandatories = ['info'];
-        foreach ($mandatories as $consent) {
-            if (!in_array($consent, $consents)) {
-                array_unshift($consents, $consent);
-            }
-        }
-
-        return $consents;
-    }
-
-    /**
      * @param \ModuleCore $module
      * @param array $requiredConsents
      * @param array $optionalConsents
@@ -98,7 +81,9 @@ class PresenterService
      */
     public function expose(\ModuleCore $module, $requiredConsents = [], $optionalConsents = [])
     {
-        $requiredConsents = $this->enforceMandatoryConsents($requiredConsents);
+        if (!in_array('info', $requiredConsents)) {
+            array_unshift($requiredConsents, 'info');
+        }
         if ($this->psAccountsService == null) {
             return [];
         } else {

--- a/src/Service/PresenterService.php
+++ b/src/Service/PresenterService.php
@@ -79,7 +79,7 @@ class PresenterService
      */
     private function enforceMandatoryConsents($consents)
     {
-        $mandatories = ['info', 'modules', 'themes'];
+        $mandatories = ['info'];
         foreach ($mandatories as $consent) {
             if (!in_array($consent, $consents)) {
                 array_unshift($consents, $consent);


### PR DESCRIPTION
The presenterService expose the required consents to the MSC.
Deleting "modules" and "themes" make that only "info" is required.
(explanation from Mikatux)