### PR TITLE
chore(makefile): missing zip generation by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ version:
 
 # target: zip                                                  - Make zip bundles
 .PHONY: zip
-zip: zip-prod zip-inte
+zip: zip-prod zip-inte zip-e2e
 dist:
 	@mkdir -p ./dist
 


### PR DESCRIPTION
Useful when you need to test out a new beta in any E2E env :)