### PR TITLE
fix(push-collector): max-execution-time issue

### DIFF
--- a/src/Api/CollectorApiClient.php
+++ b/src/Api/CollectorApiClient.php
@@ -31,6 +31,7 @@ class CollectorApiClient
 
     /**
      * Default maximum execution time in seconds
+     *
      * @see https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time
      */
     private static $DEFAULT_MAX_EXECUTION_TIME = 30;
@@ -50,6 +51,7 @@ class CollectorApiClient
     /**
      * @see https://docs.guzzlephp.org/en/stable/quickstart.html
      * @see https://docs.guzzlephp.org/en/stable/request-options.html#read-timeout
+     *
      * @param int $startTime @optional start time in seconds since epoch
      *
      * @return HttpClientInterface
@@ -164,6 +166,7 @@ class CollectorApiClient
     {
         /**
          * Negative remaining time means an immediate timeout (0 means infinity)
+         *
          * @see https://docs.guzzlephp.org/en/stable/request-options.html?highlight=timeout#timeout
          */
         $maxExecutionTime = (int) ini_get('max_execution_time');
@@ -184,7 +187,7 @@ class CollectorApiClient
         }
 
         $remainingTime = $maxExecutionTime - $extraOpsTime - (time() - $startTime);
-        
+
         // A protection that might never be used, but who knows
         if ($remainingTime <= 0) {
             return CollectorApiClient::$DEFAULT_MAX_EXECUTION_TIME;

--- a/src/Api/CollectorApiClient.php
+++ b/src/Api/CollectorApiClient.php
@@ -62,7 +62,7 @@ class CollectorApiClient
     {
         return (new ClientFactory())->getClient([
             'allow_redirects' => true,
-            'connect_timeout' => 3,
+            'connect_timeout' => 10,
             'http_errors' => false,
             'read_timeout' => 30,
             'timeout' => $this->getRemainingTime($startTime),

--- a/src/Api/CollectorApiClient.php
+++ b/src/Api/CollectorApiClient.php
@@ -33,6 +33,7 @@ class CollectorApiClient
      * Default maximum execution time in seconds
      *
      * @see https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time
+     *
      * @var int
      */
     private static $DEFAULT_MAX_EXECUTION_TIME = 30;

--- a/src/Api/CollectorApiClient.php
+++ b/src/Api/CollectorApiClient.php
@@ -33,6 +33,7 @@ class CollectorApiClient
      * Default maximum execution time in seconds
      *
      * @see https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time
+     * @var int
      */
     private static $DEFAULT_MAX_EXECUTION_TIME = 30;
 

--- a/src/Api/LiveSyncApiClient.php
+++ b/src/Api/LiveSyncApiClient.php
@@ -58,7 +58,7 @@ class LiveSyncApiClient
     {
         return (new ClientFactory())->getClient([
             'allow_redirects' => true,
-            'connect_timeout' => 3,
+            'connect_timeout' => 10,
             'http_errors' => false,
             'timeout' => $timeout,
         ]);

--- a/src/Api/SyncApiClient.php
+++ b/src/Api/SyncApiClient.php
@@ -58,7 +58,7 @@ class SyncApiClient
     {
         return (new ClientFactory())->getClient([
             'allow_redirects' => true,
-            'connect_timeout' => 3,
+            'connect_timeout' => 10,
             'http_errors' => false,
             'timeout' => $timeout,
         ]);


### PR DESCRIPTION
# Description 

When a shop is using a `max_execution_time` setting to 0 in its PHP configuration, the previous computation algorithm of remaining time to perform the curl request was defaulting to 0.1s. Which is obviously a ridiculous time to perform any form of synchronization.

* [x] Default to 30s if max_execution_time <= 0s or remaining time <= 1.5s
* [x] Connect timeout from 3s to 10s (if server is unavailable or under heavy load)

The new algorithm fixes this.

## Related tickets (internal)

* https://forge.prestashop.com/browse/EB-1337
* https://forge.prestashop.com/browse/EB-1303
* https://forge.prestashop.com/browse/EB-1386
* https://forge.prestashop.com/browse/EB-1392
* https://forge.prestashop.com/browse/EB-1415

## How to diagnose

```
$ php -a
php > printf(ini_get('max_execution_time'));
0
```


