### PR TITLE
chore(lint): fix PHP lint to ignore path rather than forcing it

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,13 +1,15 @@
 <?php
 
-$config = new PrestaShop\CodingStandards\CsFixer\Config();
-
-$config
-    ->setUsingCache(true)
-    ->getFinder()
+$finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
     ->exclude('translations')
     ->exclude('prestashop')
+    ->exclude('tools')
     ->exclude('vendor');
+
+$config = new PrestaShop\CodingStandards\CsFixer\Config();
+$config
+    ->setUsingCache(false)
+    ->setFinder($finder);
 
 return $config;

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ docker-php-cs-fixer-fix: tools/vendor
 # target: php-lint (or docker-php-lint)                        - Lint the code with the php linter
 .PHONY: php-lint docker-php-lint
 php-lint:
-	@find . -type f -name '*.php' -not -path 'vendor' -and -path 'tools/vendor' -print0 | xargs -0 -n1 php -l -n | (! grep -v "No syntax errors" );
+	@find . -type f -name '*.php' -not -path 'vendor' -and -not -path 'tools/vendor' -print0 | xargs -0 -n1 php -l -n | (! grep -v "No syntax errors" );
 	@echo "php $(shell php -r 'echo PHP_VERSION;') lint passed";
 docker-php-lint:
 	@$(call in_docker,make,php-lint)

--- a/Makefile
+++ b/Makefile
@@ -129,14 +129,14 @@ docker-lint-fix: docker-php-cs-fixer-fix
 # target: php-cs-fixer (or docker-php-cs-fixer)                - Lint the code and expose errors
 .PHONY: php-cs-fixer docker-php-cs-fixer  
 php-cs-fixer: tools/vendor
-	@php-cs-fixer fix --dry-run --diff --using-cache=no;
+	@php-cs-fixer fix --dry-run --diff --using-cache=no --config=.php-cs-fixer.dist.php;
 docker-php-cs-fixer: tools/vendor
 	@$(call in_docker,make,lint)
 
 # target: php-cs-fixer-fix (or docker-php-cs-fixer-fix)        - Lint the code and fix it
 .PHONY: php-cs-fixer-fix docker-php-cs-fixer-fix
 php-cs-fixer-fix: tools/vendor
-	@php-cs-fixer fix --using-cache=no;
+	@php-cs-fixer fix --using-cache=no --config=.php-cs-fixer.dist.php
 docker-php-cs-fixer-fix: tools/vendor
 	@$(call in_docker,make,lint-fix)
 

--- a/Makefile
+++ b/Makefile
@@ -129,21 +129,21 @@ docker-lint-fix: docker-php-cs-fixer-fix
 # target: php-cs-fixer (or docker-php-cs-fixer)                - Lint the code and expose errors
 .PHONY: php-cs-fixer docker-php-cs-fixer  
 php-cs-fixer: tools/vendor
-	@php-cs-fixer fix --dry-run --diff --using-cache=no --config=.php-cs-fixer.dist.php;
+	@php-cs-fixer fix --dry-run --diff;
 docker-php-cs-fixer: tools/vendor
 	@$(call in_docker,make,lint)
 
 # target: php-cs-fixer-fix (or docker-php-cs-fixer-fix)        - Lint the code and fix it
 .PHONY: php-cs-fixer-fix docker-php-cs-fixer-fix
 php-cs-fixer-fix: tools/vendor
-	@php-cs-fixer fix --using-cache=no --config=.php-cs-fixer.dist.php
+	@php-cs-fixer fix
 docker-php-cs-fixer-fix: tools/vendor
 	@$(call in_docker,make,lint-fix)
 
 # target: php-lint (or docker-php-lint)                        - Lint the code with the php linter
 .PHONY: php-lint docker-php-lint
 php-lint:
-	@find . -type f -name '*.php' -not -path 'vendor' -and -not -path 'tools/vendor' -print0 | xargs -0 -n1 php -l -n | (! grep -v "No syntax errors" );
+	@find . -type f -name '*.php' -not -path "./vendor/*" -not -path "./tools/*" -not -path "./prestashop/*" -print0 | xargs -0 -n1 php -l -n | (! grep -v "No syntax errors" );
 	@echo "php $(shell php -r 'echo PHP_VERSION;') lint passed";
 docker-php-lint:
 	@$(call in_docker,make,php-lint)


### PR DESCRIPTION
As reported by @Quetzacoalt91 (thank you 🙏 ) a slight issue was preventing from accurate lint checks for each PHP version.