### PR TITLE
fix: multistore compat scoped to 1.7.8.0

### DIFF
--- a/ps_eventbus.php
+++ b/ps_eventbus.php
@@ -156,7 +156,7 @@ class Ps_eventbus extends Module
      */
     public function __construct()
     {
-        if (version_compare(_PS_VERSION_, '1.7', '>=')) {
+        if (version_compare(_PS_VERSION_, '1.7.8.0', '>=')) {
             $this->multistoreCompatibility = parent::MULTISTORE_COMPATIBILITY_YES;
         }
 


### PR DESCRIPTION
Increases the version needed to use the "MULTISTORE_COMPATIBILITY_YES" constant of the PrestaShop Module.php class to 1.7.8.0 or greater.

see this commit: https://github.com/PrestaShop/PrestaShop/commit/d557747e91386d826eaac3d24a84382322525853