### PR TITLE
fix: missing hooks (employees and translations)

### DIFF
--- a/ps_eventbus.php
+++ b/ps_eventbus.php
@@ -1403,7 +1403,7 @@ class Ps_eventbus extends Module
      * For security reasons, I like to use the before hook, and put it in a try/catch
      *
      * @param array $parameters
-     * 
+     *
      * @return void
      */
     public function hookActionDispatcherBefore($parameters)

--- a/ps_eventbus.php
+++ b/ps_eventbus.php
@@ -25,6 +25,7 @@
  */
 
 use PrestaShop\Module\PsEventbus\Config\Config;
+use PrestaShopBundle\EventListener\ActionDispatcherLegacyHooksSubscriber;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -1409,6 +1410,10 @@ class Ps_eventbus extends Module
     public function hookActionDispatcherBefore($parameters)
     {
         try {
+            if ($parameters['controller_type'] != ActionDispatcherLegacyHooksSubscriber::BACK_OFFICE_CONTROLLER) {
+                return;
+            }
+
             $route = $parameters['route'];
 
             // when translation is edited or reset, add to incremental sync
@@ -1421,6 +1426,7 @@ class Ps_eventbus extends Module
                 );
             }
         } catch (\Exception $e) {
+            return;
         }
     }
 

--- a/ps_eventbus.php
+++ b/ps_eventbus.php
@@ -124,6 +124,12 @@ class Ps_eventbus extends Module
         'actionObjectZoneDeleteAfter',
         'actionObjectZoneUpdateAfter',
         'actionShippingPreferencesPageSave',
+
+        'actionObjectEmployeeAddAfter',
+        'actionObjectEmployeeDeleteAfter',
+        'actionObjectEmployeeUpdateAfter',
+
+        'actionDispatcherBefore',
     ];
 
     /**
@@ -1346,6 +1352,73 @@ class Ps_eventbus extends Module
             date(DATE_ATOM),
             $this->shopId
         );
+    }
+
+    /**
+     * @return void
+     */
+    public function hookActionObjectEmployeeAddAfter()
+    {
+        $this->insertIncrementalSyncObject(
+            0,
+            Config::COLLECTION_EMPLOYEES,
+            date(DATE_ATOM),
+            $this->shopId
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function hookActionObjectEmployeeDeleteAfter()
+    {
+        $this->insertIncrementalSyncObject(
+            0,
+            Config::COLLECTION_EMPLOYEES,
+            date(DATE_ATOM),
+            $this->shopId
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function hookActionObjectEmployeeUpdateAfter()
+    {
+        $this->insertIncrementalSyncObject(
+            0,
+            Config::COLLECTION_EMPLOYEES,
+            date(DATE_ATOM),
+            $this->shopId
+        );
+    }
+
+    /**
+     * This is global hook. This hook is called at the beginning of the dispatch method of the Dispatcher
+     * It's possible to use this hook all time when we don't have specific hook.
+     * Available since: 1.7.1
+     * 
+     * Unable to use hookActionDispatcherAfter. Seem to be have a strange effect. When i use 
+     * this hook and try to dump() the content, no dump appears in the symfony debugger, and no more hooks appear.
+     * For security reasons, I like to use the before hook, and put it in a try/catch
+     * 
+     * @return void
+     */
+    public function hookActionDispatcherBefore($parameters)
+    {
+        try {
+            $route = $parameters['route'];
+
+            // when translation is edited or reset, add to incremental sync
+            if ($route == 'api_translation_value_edit' || $route == 'api_translation_value_reset') {
+                $this->insertIncrementalSyncObject(
+                    0,
+                    Config::COLLECTION_TRANSLATIONS,
+                    date(DATE_ATOM),
+                    $this->shopId
+                );
+            }
+        } catch (\Exception $e) {}
     }
 
     /**

--- a/ps_eventbus.php
+++ b/ps_eventbus.php
@@ -1397,10 +1397,12 @@ class Ps_eventbus extends Module
      * This is global hook. This hook is called at the beginning of the dispatch method of the Dispatcher
      * It's possible to use this hook all time when we don't have specific hook.
      * Available since: 1.7.1
-     * 
-     * Unable to use hookActionDispatcherAfter. Seem to be have a strange effect. When i use 
+     *
+     * Unable to use hookActionDispatcherAfter. Seem to be have a strange effect. When i use
      * this hook and try to dump() the content, no dump appears in the symfony debugger, and no more hooks appear.
      * For security reasons, I like to use the before hook, and put it in a try/catch
+     *
+     * @param array $parameters
      * 
      * @return void
      */
@@ -1418,7 +1420,8 @@ class Ps_eventbus extends Module
                     $this->shopId
                 );
             }
-        } catch (\Exception $e) {}
+        } catch (\Exception $e) {
+        }
     }
 
     /**

--- a/upgrade/Upgrade-3.0.5.php
+++ b/upgrade/Upgrade-3.0.5.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @return bool
+ */
+function upgrade_module_3_0_5($module)
+{
+    $module->registerhook('actionObjectEmployeeAddAfter');
+    $module->registerhook('actionObjectEmployeeDeleteAfter');
+    $module->registerhook('actionObjectEmployeeUpdateAfter');
+
+    return true;
+}


### PR DESCRIPTION
I have added missing hook for two shop content: 
- Employees
- Translations

See this for hook list : https://devdocs.prestashop-project.org/1.7/modules/concepts/hooks/list-of-hooks/