### PR TITLE
fix ps_account_mock zip url

### DIFF
--- a/e2e-env/init-scripts/install-module.sh
+++ b/e2e-env/init-scripts/install-module.sh
@@ -20,7 +20,7 @@ ps_accounts_mock_install() {
   echo "* [ps_accounts_mock] downloading..."
   PS_ACCOUNTS_MOCK_VERSION="v1.0.4"
   wget -q -O /tmp/ps_accounts.zip \
-    "https://github.com/PrestaShopCorp/ps_accounts_mock/releases/download/${PS_ACCOUNTS_MOCK_VERSION}/ps_accounts-${PS_ACCOUNTS_MOCK_VERSION}.zip"
+    "https://github.com/PrestaShopCorp/ps_accounts_mock/releases/download/${PS_ACCOUNTS_MOCK_VERSION}/ps_accounts.zip"
   echo "* [ps_accounts_mock] unziping..."
   run_user unzip -qq /tmp/ps_accounts.zip -d /var/www/html/modules
   echo "* [ps_accounts_mock] installing the module..."


### PR DESCRIPTION
Wrong url in e2e env prevents from properly testing ps_eventbus