### PR TITLE
fix(e2e): prestashop compose healthcheck

### DIFF
--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -14,6 +14,7 @@ services:
           "Host: localhost:8000",
           "http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck",
         ]
+      interval: 30s
     volumes:
       - ..:/var/www/html/modules/ps_eventbus:rw
       - ./init-scripts:/tmp/init-scripts:ro

--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -7,12 +7,14 @@ services:
     healthcheck:
       test:
         [
-          'CMD',
-          'curl',
-          '-sI',
-          'http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck',
+          "CMD",
+          "curl",
+          "-sI",
+          "-H",
+          "Host: localhost:8000",
+          "http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck",
         ]
-      interval: 1s
+      interval: 5s
       timeout: 5s
       retries: 30
     volumes:
@@ -33,12 +35,7 @@ services:
   mysql:
     image: mariadb:${DOCKER_VERSION_MARIADB:?See e2e-env/.env.dist}
     healthcheck:
-      test:
-        [
-          "CMD",
-          "healthcheck.sh",
-          "--connect",
-        ]
+      test: ["CMD", "healthcheck.sh", "--connect"]
       interval: 1s
       timeout: 10s
       retries: 30
@@ -77,13 +74,7 @@ services:
     environment:
       - RUN_IN_DOCKER=1
     healthcheck:
-      test:
-        [
-          'CMD',
-          'curl',
-          '-sI',
-          'http://localhost:8080',
-        ]
+      test: ["CMD", "curl", "-sI", "http://localhost:8080"]
       interval: 1s
       timeout: 5s
       retries: 30
@@ -100,20 +91,14 @@ services:
   reverse-proxy:
     image: nginx:stable-alpine
     healthcheck:
-      test:
-        [
-          'CMD',
-          'curl',
-          '-sI',
-          'http://localhost:80/nginx_status',
-        ]
+      test: ["CMD", "curl", "-sI", "http://localhost:80/nginx_status"]
       interval: 1s
       timeout: 2s
       retries: 30
       start_period: 1s
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro,cached
-    command: [ nginx-debug, "-g", "daemon off;" ]
+    command: [nginx-debug, "-g", "daemon off;"]
     networks:
       - prestashop
     ports:

--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -6,17 +6,14 @@ services:
         condition: service_healthy
     healthcheck:
       test:
-        [
-          "CMD",
-          "curl",
-          "-sI",
-          "-H",
-          "Host: localhost:8000",
-          "http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck",
-        ]
-      interval: 5s
-      timeout: 5s
-      retries: 30
+      [
+        "CMD",
+        "curl",
+        "-sI",
+        "-H",
+        "Host: localhost:8000",
+        "http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck",
+      ]
     volumes:
       - ..:/var/www/html/modules/ps_eventbus:rw
       - ./init-scripts:/tmp/init-scripts:ro

--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -6,14 +6,14 @@ services:
         condition: service_healthy
     healthcheck:
       test:
-      [
-        "CMD",
-        "curl",
-        "-sI",
-        "-H",
-        "Host: localhost:8000",
-        "http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck",
-      ]
+        [
+          "CMD",
+          "curl",
+          "-sI",
+          "-H",
+          "Host: localhost:8000",
+          "http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck",
+        ]
     volumes:
       - ..:/var/www/html/modules/ps_eventbus:rw
       - ./init-scripts:/tmp/init-scripts:ro

--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -33,9 +33,6 @@ services:
     image: mariadb:${DOCKER_VERSION_MARIADB:?See e2e-env/.env.dist}
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect"]
-      interval: 1s
-      timeout: 10s
-      retries: 30
     environment:
       - MYSQL_HOST=mysql
       - MYSQL_USER=prestashop
@@ -72,9 +69,6 @@ services:
       - RUN_IN_DOCKER=1
     healthcheck:
       test: ["CMD", "curl", "-sI", "http://localhost:8080"]
-      interval: 1s
-      timeout: 5s
-      retries: 30
     volumes:
       - ./cloudsync-mock/src:/home/node/src:ro
     ports:
@@ -89,10 +83,6 @@ services:
     image: nginx:stable-alpine
     healthcheck:
       test: ["CMD", "curl", "-sI", "http://localhost:80/nginx_status"]
-      interval: 1s
-      timeout: 2s
-      retries: 30
-      start_period: 1s
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro,cached
     command: [nginx-debug, "-g", "daemon off;"]


### PR DESCRIPTION
The previous implementation was failing with a 302 redirect.
As mentioned in Flashlight documentation, multi-shop configuration requires a `Host` header given, if you aim at calling APIs from the Flashlight container itself.