### PR TITLE
fix: disable healthcheck v2 and set new version for update file

### DIFF
--- a/controllers/front/apiHealthCheck.php
+++ b/controllers/front/apiHealthCheck.php
@@ -20,12 +20,12 @@ class ps_EventbusApiHealthCheckModuleFrontController extends AbstractApiControll
      */
     public function init()
     {
-        /* 
+        /*
         try {
             parent::init();
         } catch (UnauthorizedException $exception) {
             $this->isAuthentifiedCall = false;
-        } 
+        }
         */
     }
 

--- a/controllers/front/apiHealthCheck.php
+++ b/controllers/front/apiHealthCheck.php
@@ -20,11 +20,13 @@ class ps_EventbusApiHealthCheckModuleFrontController extends AbstractApiControll
      */
     public function init()
     {
+        /* 
         try {
             parent::init();
         } catch (UnauthorizedException $exception) {
             $this->isAuthentifiedCall = false;
-        }
+        } 
+        */
     }
 
     /**

--- a/upgrade/Upgrade-3.0.13.php
+++ b/upgrade/Upgrade-3.0.13.php
@@ -5,7 +5,7 @@ use PrestaShop\Module\PsEventbus\Config\Config;
 /**
  * @return bool
  */
-function upgrade_module_3_1_0()
+function upgrade_module_3_0_13()
 {
     $db = Db::getInstance();
 


### PR DESCRIPTION
- Disable healthcheck V2 for new release (not available on back-end);
- Change name of update file for 3.0.13