### PR TITLE
run e2e tests against good Prestashop version

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -91,7 +91,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     strategy:
       matrix:
-        ps_version: ["1.7.8.10", "8.1.6", "nightly"]
+        ps_version: ["1.7.8.10", "8.1.4", "nightly"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
run e2e-tests against 8.1.4 instead of 8.1.6 due to unpredictable results with newer versions.