### PR TITLE
fix(ci): bump Node.js from 20 to 22 for pnpm 11+ compatibility

### DIFF
--- a/.github/workflows/build-release-publish.yml
+++ b/.github/workflows/build-release-publish.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   PHP_BUILDER_VERSION: "8.3"
-  NODE_BUILDER_VERSION: "20"
+  NODE_BUILDER_VERSION: "22"
   DOCKER_COMPOSE_VERSION: v2.27.0
   GITHUB_TOKEN: ${{ secrets.GA_ACCESS_TOKEN }}
   VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -1,7 +1,7 @@
 name: Quality Control
 
 env:
-  NODE_BUILDER_VERSION: "20"
+  NODE_BUILDER_VERSION: "22"
 
 on:
   pull_request:

--- a/e2e-env/cloudsync-mock/Dockerfile
+++ b/e2e-env/cloudsync-mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:26-alpine
 
 RUN apk add --no-cache curl
 

--- a/e2e-env/cloudsync-mock/Dockerfile
+++ b/e2e-env/cloudsync-mock/Dockerfile
@@ -9,10 +9,7 @@ RUN npm install -g pnpm
 WORKDIR /home/node
 ADD . /home/node
 
-# Avoid "failed to compile" error from ARM deps shipped in pnpm-lock.yaml
-RUN rm pnpm-lock.yaml \
-  && pnpm install \
-  && pnpm run build
+RUN pnpm install && pnpm run build
 
 ENTRYPOINT [ "pnpm" ]
 CMD [ "start" ]

--- a/e2e-env/cloudsync-mock/Dockerfile
+++ b/e2e-env/cloudsync-mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.10-alpine
+FROM node:22-alpine
 
 RUN apk add --no-cache curl
 

--- a/e2e-env/cloudsync-mock/package.json
+++ b/e2e-env/cloudsync-mock/package.json
@@ -7,7 +7,7 @@
   "engines": {
     "yarn": "please use pnpm",
     "npm": "please use pnpm",
-    "node": ">=18",
+    "node": ">=26",
     "pnpm": ">=8"
   },
   "scripts": {

--- a/e2e-env/cloudsync-mock/pnpm-lock.yaml
+++ b/e2e-env/cloudsync-mock/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       express:
         specifier: ^4.19.2
         version: 4.19.2
+      multer:
+        specifier: ^1.4.5-lts.1
+        version: 1.4.5-lts.1
+      ws:
+        specifier: ^8.17.0
+        version: 8.17.0
     devDependencies:
       '@swc/cli':
         specifier: ^0.3.12
@@ -39,9 +45,6 @@ importers:
       eslint-plugin-import:
         specifier: ^2.29.1
         version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@9.2.0)(typescript@5.4.5))(eslint@9.2.0)
-      multer:
-        specifier: ^1.4.5-lts.1
-        version: 1.4.5-lts.1
       nodemon:
         specifier: ^3.1.0
         version: 3.1.0
@@ -51,9 +54,6 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
-      ws:
-        specifier: ^8.17.0
-        version: 8.17.0
 
 packages:
 
@@ -78,6 +78,7 @@ packages:
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -85,6 +86,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/retry@0.2.4':
     resolution: {integrity: sha512-Ttl/jHpxfS3st5sxwICYfk4pOH0WrLI1SpW283GgQL7sCWU7EHIOhX4b4fkIxr3tkfzwg8+FNojtzsIEE7Ecgg==}
@@ -152,24 +154,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.5.6':
     resolution: {integrity: sha512-Jntdd/HQAgRSQFUpmXjiU00BG08Yl5G1pgYDBXG2mPfkndGGgapRT8JPsnzfQujh9nOdWMIQDnCGU+mB4NY2Dg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.5.6':
     resolution: {integrity: sha512-cdaAyAZJvYCx0u9uadUVe4VVJOEC6GeVO5uTGo/vybCsKFn2Z8WVjGVTeHbxdp7pH2II9MRTySIv1eCCq70SOQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.5.6':
     resolution: {integrity: sha512-mGIs4d6/Hv/5EbP2d+2YNmIj9U5U/6CiPZsTyahQcEl+vJjNsmwDJoLex36LhxoGIUmVbbgk6cHj5DoHWNl0bQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.5.6':
     resolution: {integrity: sha512-ViiS2pUXy/J9RZWJXQJMuDKid0lqH9fu2piFi3IHnMWyyWPla5qHYijkeODwrdBsjc30NAHjV6jfka5SZduqiw==}
@@ -862,6 +868,7 @@ packages:
   glob@10.3.15:
     resolution: {integrity: sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==}
     engines: {node: '>=16 || 14 >=14.18'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -1189,6 +1196,7 @@ packages:
   multer@1.4.5-lts.1:
     resolution: {integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==}
     engines: {node: '>= 6.0.0'}
+    deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}

--- a/e2e-env/cloudsync-mock/pnpm-workspace.yaml
+++ b/e2e-env/cloudsync-mock/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@swc/core': set this to true or false
+  nice-napi: set this to true or false

--- a/e2e-env/cloudsync-mock/pnpm-workspace.yaml
+++ b/e2e-env/cloudsync-mock/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 allowBuilds:
-  '@swc/core': set this to true or false
-  nice-napi: set this to true or false
+  '@swc/core': true
+  nice-napi: true


### PR DESCRIPTION
## Summary

- pnpm now requires to approve build scripts from dependencies => keep logfile and update it
- update to node 26