### PR TITLE
fix: build multipart upload without tmpfile() (compat) + preserve Authorization header

### DIFF
--- a/src/Api/HttpClient.php
+++ b/src/Api/HttpClient.php
@@ -395,7 +395,10 @@ class HttpClient
                 . "\r\n--{$boundary}--\r\n";
             $this->setOpt(CURLOPT_POST, true);
             $this->setOpt(CURLOPT_POSTFIELDS, $body);
-            $this->setOpt(CURLOPT_HTTPHEADER, ['Content-Type: multipart/form-data; boundary=' . $boundary]);
+            // Merge boundary Content-Type into _headers, otherwise this overwrites
+            // CURLOPT_HTTPHEADER and drops Authorization/User-Agent set above.
+            $this->_headers['Content-Type'] = 'Content-Type: multipart/form-data; boundary=' . $boundary;
+            $this->setOpt(CURLOPT_HTTPHEADER, array_values($this->_headers));
         } else {
             $this->prepareJsonPayload($data);
         }


### PR DESCRIPTION
## Summary

Reinstates #468 (build multipart upload without `tmpfile()`) — reverted in #471 because the original change dropped the `Authorization` header — and adds the missing header fix on top.

### Why avoid `tmpfile()`

Compatibility: some hosting environments restrict `tmpfile()` / `sys_get_temp_dir`, causing CloudSync uploads to fail. Building the multipart body in memory removes that dependency.

### Why #471 reverted #468

Switching from `CURLFile` + `preparePayload()` to manual `CURLOPT_POSTFIELDS` overwrote `CURLOPT_HTTPHEADER`, dropping `Authorization` and `User-Agent` set earlier in the request.

### Fix

Merge the multipart `Content-Type` (with boundary) into `$this->_headers` and re-apply the full header set via `CURLOPT_HTTPHEADER`, so auth headers survive.

## Test plan

- [ ] e2e: trigger CloudSync upload on env without `tmpfile()` support — request succeeds
- [ ] Verify `Authorization` header present on multipart POST (trace log / server-side)
- [ ] Regression: JSON (non-multipart) POST still works