### PR TITLE
Revert "fix: build multipart upload without tmpfile() (#468)"

### DIFF
--- a/src/Api/HttpClient.php
+++ b/src/Api/HttpClient.php
@@ -372,35 +372,38 @@ class HttpClient
      * @param string $url The url to make the post request
      * @param array $headers Optional headers to pass to the url
      * @param array $data Post data to pass to the url
-     * @param bool $isMultipart If there is a multipart, set it to true or False if it is a json
+     * @param bool $isFile If there is a multipart, set it to true or False if it is a json
      *
      * @return self
      */
-    public function post($url, array $headers = [], array $data = [], $isMultipart = null)
+    public function post($url, array $headers = [], array $data = [], $isFile = null)
     {
-        if (is_null($isMultipart)) {
-            $isMultipart = false;
+        if (is_null($isFile)) {
+            $isFile = false;
         }
 
         $this->setHeaders($headers);
         $this->setOpt(CURLOPT_URL, $url);
 
-        if ($isMultipart) {
-            $boundary = uniqid('', true);
-            // proper way to do this would be to use CURLStringFile, only with php >= 8.1.0
-            $body = "--{$boundary}\r\n"
-                . "Content-Disposition: form-data; name=\"file\"; filename=\"file\"\r\n"
-                . "Content-Type: text/plain\r\n\r\n"
-                . $this->formatNewlineJsonString($data)
-                . "\r\n--{$boundary}--\r\n";
-            $this->setOpt(CURLOPT_POST, true);
-            $this->setOpt(CURLOPT_POSTFIELDS, $body);
-            $this->setOpt(CURLOPT_HTTPHEADER, ['Content-Type: multipart/form-data; boundary=' . $boundary]);
+        if ($isFile) {
+            // Créer un fichier temporaire
+            $temp = tmpfile();
+            fwrite($temp, $this->formatNewlineJsonString($data));
+            rewind($temp);
+
+            // Sauvegarder le fichier temporaire pour cURL
+            $tempPath = stream_get_meta_data($temp)['uri'];
+            $payload = ['file' => new \CURLFile($tempPath, 'text/plain', 'file')];
+            $this->preparePayload($payload);
         } else {
             $this->prepareJsonPayload($data);
         }
 
         $this->exec();
+
+        if ($isFile) {
+            fclose($temp);
+        }
 
         return $this;
     }


### PR DESCRIPTION
This reverts commit eaf368525b0c9490bd636665fc5478f30869e39d.


Change causes Authorization problems. This is a hotfix to resolve auth problems for affected clients.