### PR TITLE
chore(debug): add gated HTTP tracer + e2e production profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ sonar-project.properties
 
 ### Mytuns
 credentials.json
-trace.log
+trace-*.log

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ sonar-project.properties
 
 ### Mytuns
 credentials.json
+trace.log

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,11 @@
 <module>
     <name>ps_eventbus</name>
     <displayName><![CDATA[PrestaShop EventBus]]></displayName>
-    <version><![CDATA[0.0.0]]></version>
+    <!-- Must be 4.0.0+ — CloudSync routes sync requests to apiShopContent only when the
+         module reports v4+. Lower versions get routed to legacy controllers (apiOrders,
+         apiInfo, …) that this module no longer ships, breaking e2e against real CloudSync.
+         The Makefile's replace_version rewrites this at zip build time from the git tag. -->
+    <version><![CDATA[4.0.0]]></version>
     <description><![CDATA[Link your PrestaShop account to synchronize your shop data to a tech partner of your choice. Do not uninstall this module if you are already using a service, as it will prevent it from working.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[administration]]></tab>

--- a/controllers/front/apiHealthCheck.php
+++ b/controllers/front/apiHealthCheck.php
@@ -40,6 +40,8 @@ class ps_EventbusApiHealthCheckModuleFrontController extends ModuleFrontControll
      */
     public function postProcess()
     {
+        \PrestaShop\Module\PsEventbus\Api\HttpClient::traceIncoming('apiHealthCheck');
+
         /** @var string $jobId */
         $jobId = Tools::getValue('job_id');
 

--- a/controllers/front/apiHealthCheck.php
+++ b/controllers/front/apiHealthCheck.php
@@ -40,7 +40,7 @@ class ps_EventbusApiHealthCheckModuleFrontController extends ModuleFrontControll
      */
     public function postProcess()
     {
-        \PrestaShop\Module\PsEventbus\Api\HttpClient::traceIncoming('apiHealthCheck');
+        PrestaShop\Module\PsEventbus\Api\HttpClient::traceIncoming('apiHealthCheck');
 
         /** @var string $jobId */
         $jobId = Tools::getValue('job_id');

--- a/controllers/front/apiShopContent.php
+++ b/controllers/front/apiShopContent.php
@@ -40,6 +40,8 @@ class ps_EventbusApiShopContentModuleFrontController extends ModuleFrontControll
      */
     public function postProcess()
     {
+        \PrestaShop\Module\PsEventbus\Api\HttpClient::traceIncoming('apiShopContent');
+
         /** @var string $shopContent */
         $shopContent = Tools::getValue('shop_content');
 

--- a/controllers/front/apiShopContent.php
+++ b/controllers/front/apiShopContent.php
@@ -40,7 +40,7 @@ class ps_EventbusApiShopContentModuleFrontController extends ModuleFrontControll
      */
     public function postProcess()
     {
-        \PrestaShop\Module\PsEventbus\Api\HttpClient::traceIncoming('apiShopContent');
+        PrestaShop\Module\PsEventbus\Api\HttpClient::traceIncoming('apiShopContent');
 
         /** @var string $shopContent */
         $shopContent = Tools::getValue('shop_content');

--- a/e2e-env/.env.dist
+++ b/e2e-env/.env.dist
@@ -1,4 +1,9 @@
 COMPOSE_PROJECT_NAME=ps_eventbus
+# Profiles:
+#   localhost   - local shop + ps-accounts mock + cloudsync-mock (default)
+#   cloudflared - shop exposed via Cloudflare tunnel + real ps-accounts + cloudsync-mock
+#   production  - shop exposed via Cloudflare tunnel + real ps-accounts + REAL CloudSync (uses .config.prod.php)
+#   cicd        - localhost-style for CI
 COMPOSE_PROFILES=localhost
 
 # Infrastructure dependencies

--- a/e2e-env/README.md
+++ b/e2e-env/README.md
@@ -75,38 +75,3 @@ docker compose build --no-cache
 ## Usage
 
 Once the environment is running, navigate to the e2e directory and run the e2e tests.
-
-## Production profile (real ps-accounts + real CloudSync)
-
-Use the `production` profile to point the e2e shop at the real CloudSync prod URLs (from `.config.prod.php`) and authenticate against real `ps-accounts` via a Cloudflare tunnel.
-
-1. Create a Cloudflare tunnel and credentials file:
-
-   ```shell
-   cloudflared tunnel login                       # opens browser, picks a zone
-   cloudflared tunnel create ps-eventbus-e2e      # outputs <TUNNEL_UUID>.json credentials
-   cloudflared tunnel route dns ps-eventbus-e2e <your-hostname>.example.com
-   cp ~/.cloudflared/<TUNNEL_UUID>.json ./credentials.json
-   ```
-
-   The `credentials.json` file must contain the tunnel credentials (`AccountTag`, `TunnelSecret`, `TunnelID`).
-
-2. Configure `.env`:
-
-   ```env
-   COMPOSE_PROFILES=production
-   TUNNEL_NAME=<your-hostname>.example.com
-   ```
-
-3. Start the stack:
-
-   ```shell
-   docker compose up
-   ```
-
-   The `prestashop-prod` service mounts `../.config.prod.php` over the module's `config.php`, so requests go to:
-   - `https://eventbus-proxy.psessentials.net`
-   - `https://eventbus-sync.psessentials.net`
-   - `https://api.cloudsync.prestashop.com/live-sync/v1`
-
-   The `cloudsync-mock` and `reverse-proxy` containers are not started under this profile.

--- a/e2e-env/README.md
+++ b/e2e-env/README.md
@@ -75,3 +75,38 @@ docker compose build --no-cache
 ## Usage
 
 Once the environment is running, navigate to the e2e directory and run the e2e tests.
+
+## Production profile (real ps-accounts + real CloudSync)
+
+Use the `production` profile to point the e2e shop at the real CloudSync prod URLs (from `.config.prod.php`) and authenticate against real `ps-accounts` via a Cloudflare tunnel.
+
+1. Create a Cloudflare tunnel and credentials file:
+
+   ```shell
+   cloudflared tunnel login                       # opens browser, picks a zone
+   cloudflared tunnel create ps-eventbus-e2e      # outputs <TUNNEL_UUID>.json credentials
+   cloudflared tunnel route dns ps-eventbus-e2e <your-hostname>.example.com
+   cp ~/.cloudflared/<TUNNEL_UUID>.json ./credentials.json
+   ```
+
+   The `credentials.json` file must contain the tunnel credentials (`AccountTag`, `TunnelSecret`, `TunnelID`).
+
+2. Configure `.env`:
+
+   ```env
+   COMPOSE_PROFILES=production
+   TUNNEL_NAME=<your-hostname>.example.com
+   ```
+
+3. Start the stack:
+
+   ```shell
+   docker compose up
+   ```
+
+   The `prestashop-prod` service mounts `../.config.prod.php` over the module's `config.php`, so requests go to:
+   - `https://eventbus-proxy.psessentials.net`
+   - `https://eventbus-sync.psessentials.net`
+   - `https://api.cloudsync.prestashop.com/live-sync/v1`
+
+   The `cloudsync-mock` and `reverse-proxy` containers are not started under this profile.

--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -7,12 +7,12 @@ x-service:
     healthcheck:
       test:
         [
-          "CMD",
-          "curl",
-          "-sI",
-          "-H",
-          "Host: localhost:${HOST_PORT_BIND_PRESTASHOP:?See e2e-env/.env.dist}",
-          "http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck",
+          'CMD',
+          'curl',
+          '-sI',
+          '-H',
+          'Host: localhost:${HOST_PORT_BIND_PRESTASHOP:?See e2e-env/.env.dist}',
+          'http://localhost:80/index.php?fc=module&module=ps_eventbus&controller=apiHealthCheck',
         ]
       interval: 30s
     environment:
@@ -54,10 +54,28 @@ services:
       # - /var/www/html/modules/ps_eventbus/tools/vendor
     profiles: [cloudflared]
 
+  # Real ps-accounts (via cloudflared tunnel) + real CloudSync prod URLs
+  # (mounts .config.prod.php over the module config.php, bypassing cloudsync-mock/reverse-proxy)
+  prestashop-prod:
+    <<: *prestashop-base
+    environment:
+      - PS_DOMAIN=${TUNNEL_NAME}
+      - PS_PROTOCOL=https
+    ports:
+      - ${HOST_PORT_BIND_PRESTASHOP:?See e2e-env/.env.dist}:80
+    volumes:
+      - ..:/var/www/html/modules/ps_eventbus:rw
+      - ../.config.prod.php:/var/www/html/modules/ps_eventbus/config.php:ro
+      - ./init-scripts/install-ps-eventbus.sh:/tmp/init-scripts/install-ps-eventbus.sh:ro
+      # Notice: you might enable this if your uid is not 1000, or encounter permission issues
+      # - /var/www/html/modules/ps_eventbus/vendor
+      # - /var/www/html/modules/ps_eventbus/tools/vendor
+    profiles: [production]
+
   mysql:
     image: mariadb:${DOCKER_VERSION_MARIADB:?See e2e-env/.env.dist}
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect"]
+      test: ['CMD', 'healthcheck.sh', '--connect']
     environment:
       - MYSQL_HOST=mysql
       - MYSQL_USER=prestashop
@@ -90,7 +108,7 @@ services:
     environment:
       - RUN_IN_DOCKER=1
     healthcheck:
-      test: ["CMD", "curl", "-sI", "http://localhost:8080"]
+      test: ['CMD', 'curl', '-sI', 'http://localhost:8080']
     volumes:
       - ./cloudsync-mock/src:/home/node/src:ro
     ports:
@@ -98,16 +116,18 @@ services:
       - ${COLLECTOR_API_PORT:?See e2e-env/.env.dist}:3333
       - ${LIVE_SYNC_API_PORT:?See e2e-env/.env.dist}:3434
       - ${WS_PORT:?See e2e-env/.env.dist}:8080
+    profiles: [localhost, cloudflared, cicd]
 
   reverse-proxy:
     image: nginx:stable-alpine
     healthcheck:
-      test: ["CMD", "curl", "-sI", "http://localhost:80/nginx_status"]
+      test: ['CMD', 'curl', '-sI', 'http://localhost:80/nginx_status']
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro,cached
-    command: [nginx-debug, "-g", "daemon off;"]
+    command: [nginx-debug, '-g', 'daemon off;']
     ports:
       - ${HOST_PORT_BIND_CLOUDSYNC_REVERSE_PROXY:?See e2e-env/.env.dist}:80
+    profiles: [localhost, cloudflared, cicd]
 
   cloudflared:
     image: cloudflare/cloudflared:latest
@@ -119,3 +139,15 @@ services:
     volumes:
       - ./credentials.json:/credentials.json
     profiles: [cloudflared]
+
+  # Same as cloudflared, but routes to prestashop-prod (production profile)
+  cloudflared-prod:
+    image: cloudflare/cloudflared:latest
+    command: tunnel run $${TUNNEL_NAME}
+    environment:
+      - TUNNEL_CRED_FILE=/credentials.json
+      - TUNNEL_URL=http://prestashop-prod:80
+      - TUNNEL_HTTP_HOST_HEADER=${TUNNEL_NAME}
+    volumes:
+      - ./credentials.json:/credentials.json
+    profiles: [production]

--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -61,6 +61,7 @@ services:
     environment:
       - PS_DOMAIN=${TUNNEL_NAME}
       - PS_PROTOCOL=https
+      - DEBUG_MODE=true
     ports:
       - ${HOST_PORT_BIND_PRESTASHOP:?See e2e-env/.env.dist}:80
     volumes:

--- a/ps_eventbus.php
+++ b/ps_eventbus.php
@@ -89,7 +89,11 @@ class Ps_eventbus extends Module
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->bootstrap = true;
-        $this->version = '0.0.0';
+        // Must be 4.0.0+ — CloudSync routes sync requests to apiShopContent only when
+        // the module reports v4+. Lower versions get routed to legacy controllers
+        // (apiOrders, apiInfo, …) that this module no longer ships, so every sync 404s.
+        // The Makefile's `replace_version` rewrites this at zip build time from the git tag.
+        $this->version = '4.0.0';
         $this->module_key = '7d76e08a13331c6c393755886ec8d5ce';
 
         parent::__construct();

--- a/src/Api/CloudSyncClient.php
+++ b/src/Api/CloudSyncClient.php
@@ -125,6 +125,16 @@ class CloudSyncClient
 
         $url = $this->collectorApiUrl . '/upload/' . $jobId;
 
+        // TODO: gate behind `if (defined('PS_EVENTBUS_TRACE') && PS_EVENTBUS_TRACE)` once env-driven toggle is wired
+        HttpClient::traceLog(sprintf(
+            'upload jobId=%s shopId=%s items=%d fullSync=%s url=%s',
+            $jobId,
+            $this->shopId,
+            is_array($data) ? count($data) : 0,
+            $fullSyncRequested ? '1' : '0',
+            $url
+        ));
+
         $request = $this->client->post(
             $url,
             [

--- a/src/Api/CloudSyncClient.php
+++ b/src/Api/CloudSyncClient.php
@@ -125,7 +125,6 @@ class CloudSyncClient
 
         $url = $this->collectorApiUrl . '/upload/' . $jobId;
 
-        // TODO: gate behind `if (defined('PS_EVENTBUS_TRACE') && PS_EVENTBUS_TRACE)` once env-driven toggle is wired
         HttpClient::traceLog(sprintf(
             'upload jobId=%s shopId=%s items=%d fullSync=%s url=%s',
             $jobId,

--- a/src/Api/CloudSyncClient.php
+++ b/src/Api/CloudSyncClient.php
@@ -129,7 +129,7 @@ class CloudSyncClient
             'upload jobId=%s shopId=%s items=%d fullSync=%s url=%s',
             $jobId,
             $this->shopId,
-            is_array($data) ? count($data) : 0,
+            count($data),
             $fullSyncRequested ? '1' : '0',
             $url
         ));

--- a/src/Api/HttpClient.php
+++ b/src/Api/HttpClient.php
@@ -265,7 +265,6 @@ class HttpClient
      */
     protected function exec()
     {
-        // TODO: gate behind `if (defined('PS_EVENTBUS_TRACE') && PS_EVENTBUS_TRACE)` once env-driven toggle is wired
         $url = curl_getinfo($this->curl, CURLINFO_EFFECTIVE_URL);
         self::traceLog('→ ' . $url);
 
@@ -282,7 +281,6 @@ class HttpClient
         $this->http_error_message = $this->error ? (isset($this->response_headers['0']) ? $this->response_headers['0'] : '') : '';
         $this->error_message = $this->curl_error ? $this->getErrorMessage() : $this->http_error_message;
 
-        // TODO: gate behind `if (defined('PS_EVENTBUS_TRACE') && PS_EVENTBUS_TRACE)` once env-driven toggle is wired
         self::traceLog(sprintf(
             '← %d %s%s body=%s',
             $this->http_status_code,
@@ -305,10 +303,20 @@ class HttpClient
      */
     public static function traceLog($message)
     {
-        // Default: write next to the module sources (host-mounted) so the file appears at the repo root.
+        if (!self::isTraceEnabled()) {
+            return;
+        }
         $file = getenv('PS_EVENTBUS_TRACE_FILE') ?: dirname(dirname(__DIR__)) . '/trace.log';
         $line = '[' . date('Y-m-d H:i:s') . '] [ps_eventbus] ' . $message . "\n";
         @file_put_contents($file, $line, FILE_APPEND);
+    }
+
+    /**
+     * @return bool
+     */
+    private static function isTraceEnabled()
+    {
+        return defined('_PS_MODE_DEV_') && _PS_MODE_DEV_;
     }
 
     /**
@@ -321,7 +329,9 @@ class HttpClient
      */
     public static function traceIncoming($controller)
     {
-        // TODO: gate behind `if (defined('PS_EVENTBUS_TRACE') && PS_EVENTBUS_TRACE)` once env-driven toggle is wired
+        if (!self::isTraceEnabled()) {
+            return;
+        }
         $method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : '?';
         $uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '?';
         $remote = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '?';

--- a/src/Api/HttpClient.php
+++ b/src/Api/HttpClient.php
@@ -306,7 +306,8 @@ class HttpClient
         if (!self::isTraceEnabled()) {
             return;
         }
-        $file = getenv('PS_EVENTBUS_TRACE_FILE') ?: dirname(dirname(__DIR__)) . '/trace.log';
+        $file = getenv('PS_EVENTBUS_TRACE_FILE')
+            ?: dirname(dirname(__DIR__)) . '/trace-' . date('Y-m-d') . '.log';
         $line = '[' . date('Y-m-d H:i:s') . '] [ps_eventbus] ' . $message . "\n";
         @file_put_contents($file, $line, FILE_APPEND);
     }

--- a/src/Api/HttpClient.php
+++ b/src/Api/HttpClient.php
@@ -312,6 +312,43 @@ class HttpClient
     }
 
     /**
+     * Log an inbound HTTP request hitting one of the ps_eventbus controllers.
+     * Reads $_SERVER / $_GET / $_POST / php://input.
+     *
+     * @param string $controller short controller name (e.g. 'apiShopContent')
+     *
+     * @return void
+     */
+    public static function traceIncoming($controller)
+    {
+        // TODO: gate behind `if (defined('PS_EVENTBUS_TRACE') && PS_EVENTBUS_TRACE)` once env-driven toggle is wired
+        $method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : '?';
+        $uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '?';
+        $remote = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '?';
+        $ua = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
+        $authPresent = !empty($_SERVER['HTTP_AUTHORIZATION']) ? 'yes' : 'no';
+        $ctype = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
+        $body = '';
+        if ($method !== 'GET') {
+            $raw = @file_get_contents('php://input');
+            if ($raw !== false) {
+                $body = substr($raw, 0, 500);
+            }
+        }
+        self::traceLog(sprintf(
+            '⇆ inbound %s %s %s remote=%s auth=%s ctype=%s ua=%s body=%s',
+            $controller,
+            $method,
+            $uri,
+            $remote,
+            $authPresent,
+            $ctype,
+            substr($ua, 0, 80),
+            $body
+        ));
+    }
+
+    /**
      * @param array|object|string $data
      */
     protected function preparePayload($data)

--- a/src/Api/HttpClient.php
+++ b/src/Api/HttpClient.php
@@ -265,6 +265,10 @@ class HttpClient
      */
     protected function exec()
     {
+        // TODO: gate behind `if (defined('PS_EVENTBUS_TRACE') && PS_EVENTBUS_TRACE)` once env-driven toggle is wired
+        $url = curl_getinfo($this->curl, CURLINFO_EFFECTIVE_URL);
+        self::traceLog('→ ' . $url);
+
         $this->response_headers = [];
         $this->response = curl_exec($this->curl);
         $this->curl_error_code = curl_errno($this->curl);
@@ -278,7 +282,33 @@ class HttpClient
         $this->http_error_message = $this->error ? (isset($this->response_headers['0']) ? $this->response_headers['0'] : '') : '';
         $this->error_message = $this->curl_error ? $this->getErrorMessage() : $this->http_error_message;
 
+        // TODO: gate behind `if (defined('PS_EVENTBUS_TRACE') && PS_EVENTBUS_TRACE)` once env-driven toggle is wired
+        self::traceLog(sprintf(
+            '← %d %s%s body=%s',
+            $this->http_status_code,
+            $url,
+            $this->curl_error ? ' curl_err=' . $this->curl_error_message : '',
+            substr((string) $this->response, 0, 500)
+        ));
+
         return $this->error_code;
+    }
+
+    /**
+     * Append a trace line to the ps_eventbus log file.
+     * File path overridable via env var PS_EVENTBUS_TRACE_FILE (default: /var/log/ps_eventbus/trace.log).
+     * Host-mountable via docker-compose volume.
+     *
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function traceLog($message)
+    {
+        // Default: write next to the module sources (host-mounted) so the file appears at the repo root.
+        $file = getenv('PS_EVENTBUS_TRACE_FILE') ?: dirname(dirname(__DIR__)) . '/trace.log';
+        $line = '[' . date('Y-m-d H:i:s') . '] [ps_eventbus] ' . $message . "\n";
+        @file_put_contents($file, $line, FILE_APPEND);
     }
 
     /**

--- a/src/Service/ApiShopContentService.php
+++ b/src/Service/ApiShopContentService.php
@@ -87,14 +87,7 @@ class ApiShopContentService
     public function handleDataSync($shopContent, $jobId, $langIso, $limit, $fullSyncRequested)
     {
         try {
-            HttpClient::traceLog(sprintf(
-                'handleDataSync shopContent=%s jobId=%s langIso=%s limit=%s fullSync=%s',
-                $shopContent,
-                $jobId,
-                $langIso,
-                (string) $limit,
-                $fullSyncRequested ? '1' : '0'
-            ));
+            self::traceEntry($shopContent, $jobId, $langIso, $limit, $fullSyncRequested);
 
             if (!in_array($shopContent, Config::SHOP_CONTENTS, true)) {
                 HttpClient::traceLog('handleDataSync bail: shopContent not in Config::SHOP_CONTENTS');
@@ -107,7 +100,7 @@ class ApiShopContentService
             }
 
             $authorized = $this->apiAuthorizationService->authorize($jobId, false);
-            HttpClient::traceLog('handleDataSync authorize() returned ' . ($authorized ? 'true' : 'false'));
+            self::traceAuthorize($authorized);
 
             $response = [];
 
@@ -151,11 +144,7 @@ class ApiShopContentService
                 $offset = (int) $typeSync['offset'];
             }
 
-            HttpClient::traceLog(sprintf(
-                'handleDataSync branch: %s (offset=%d)',
-                $isFullSync ? 'sendFullSync' : 'sendIncrementalSync',
-                $offset
-            ));
+            self::traceBranch($isFullSync, $offset);
 
             if ($isFullSync) {
                 $response = $this->synchronizationService->sendFullSync(
@@ -191,5 +180,51 @@ class ApiShopContentService
         } catch (\Exception $exception) {
             $this->errorHandler->handle($exception);
         }
+    }
+
+    /**
+     * @param string $shopContent
+     * @param string $jobId
+     * @param string $langIso
+     * @param int $limit
+     * @param bool $fullSyncRequested
+     *
+     * @return void
+     */
+    private static function traceEntry($shopContent, $jobId, $langIso, $limit, $fullSyncRequested)
+    {
+        HttpClient::traceLog(sprintf(
+            'handleDataSync shopContent=%s jobId=%s langIso=%s limit=%s fullSync=%s',
+            $shopContent,
+            $jobId,
+            $langIso,
+            (string) $limit,
+            $fullSyncRequested ? '1' : '0'
+        ));
+    }
+
+    /**
+     * @param bool $authorized
+     *
+     * @return void
+     */
+    private static function traceAuthorize($authorized)
+    {
+        HttpClient::traceLog('handleDataSync authorize() returned ' . ($authorized ? 'true' : 'false'));
+    }
+
+    /**
+     * @param bool $isFullSync
+     * @param int $offset
+     *
+     * @return void
+     */
+    private static function traceBranch($isFullSync, $offset)
+    {
+        HttpClient::traceLog(sprintf(
+            'handleDataSync branch: %s (offset=%d)',
+            $isFullSync ? 'sendFullSync' : 'sendIncrementalSync',
+            $offset
+        ));
     }
 }

--- a/src/Service/ApiShopContentService.php
+++ b/src/Service/ApiShopContentService.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShop\Module\PsEventbus\Service;
 
+use PrestaShop\Module\PsEventbus\Api\HttpClient;
 use PrestaShop\Module\PsEventbus\Config\Config;
 use PrestaShop\Module\PsEventbus\Exception\QueryParamsException;
 use PrestaShop\Module\PsEventbus\Handler\ErrorHandler\ErrorHandler;
@@ -86,15 +87,27 @@ class ApiShopContentService
     public function handleDataSync($shopContent, $jobId, $langIso, $limit, $fullSyncRequested)
     {
         try {
+            HttpClient::traceLog(sprintf(
+                'handleDataSync shopContent=%s jobId=%s langIso=%s limit=%s fullSync=%s',
+                $shopContent,
+                $jobId,
+                $langIso,
+                (string) $limit,
+                $fullSyncRequested ? '1' : '0'
+            ));
+
             if (!in_array($shopContent, Config::SHOP_CONTENTS, true)) {
+                HttpClient::traceLog('handleDataSync bail: shopContent not in Config::SHOP_CONTENTS');
                 CommonService::exitWithExceptionMessage(new QueryParamsException('404 - ShopContent not found', Config::INVALID_URL_QUERY));
             }
 
             if ($limit < 0) {
+                HttpClient::traceLog('handleDataSync bail: negative limit');
                 CommonService::exitWithExceptionMessage(new QueryParamsException('Invalid URL Parameters', Config::INVALID_URL_QUERY));
             }
 
-            $this->apiAuthorizationService->authorize($jobId, false);
+            $authorized = $this->apiAuthorizationService->authorize($jobId, false);
+            HttpClient::traceLog('handleDataSync authorize() returned ' . ($authorized ? 'true' : 'false'));
 
             $response = [];
 
@@ -137,6 +150,12 @@ class ApiShopContentService
                 $fullSyncIsFinished = $typeSync['full_sync_finished'];
                 $offset = (int) $typeSync['offset'];
             }
+
+            HttpClient::traceLog(sprintf(
+                'handleDataSync branch: %s (offset=%d)',
+                $isFullSync ? 'sendFullSync' : 'sendIncrementalSync',
+                $offset
+            ));
 
             if ($isFullSync) {
                 $response = $this->synchronizationService->sendFullSync(

--- a/src/Service/SynchronizationService.php
+++ b/src/Service/SynchronizationService.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\Module\PsEventbus\Service;
 
 use PrestaShop\Module\PsEventbus\Api\CloudSyncClient;
+use PrestaShop\Module\PsEventbus\Api\HttpClient;
 use PrestaShop\Module\PsEventbus\Config\Config;
 use PrestaShop\Module\PsEventbus\Handler\ErrorHandler\ErrorHandler;
 use PrestaShop\Module\PsEventbus\Repository\IncrementalSyncRepository;
@@ -129,12 +130,22 @@ class SynchronizationService
 
         CommonService::convertDateFormat($data);
 
+        HttpClient::traceLog(sprintf(
+            'sendFullSync shopContent=%s rows=%d offset=%d limit=%d',
+            $shopContent,
+            is_array($data) ? count($data) : 0,
+            $offset,
+            $limit
+        ));
+
         if (!empty($data)) {
             $response = $this->cloudSyncClient->upload($jobId, $data, $startTime, true);
 
             if ($response['httpCode'] == 201) {
                 $offset += $limit;
             }
+        } else {
+            HttpClient::traceLog('sendFullSync skip upload: data empty');
         }
 
         $remainingObjects = (int) $shopContentApiService->getFullSyncContentLeft($offset, $limit, $langIso);
@@ -196,6 +207,14 @@ class SynchronizationService
 
         CommonService::convertDateFormat($data);
 
+        HttpClient::traceLog(sprintf(
+            'sendIncrementalSync shopContent=%s rows=%d upserts=%d deletes=%d',
+            $shopContent,
+            is_array($data) ? count($data) : 0,
+            count($upsertedContents),
+            count($deletedContents)
+        ));
+
         if (!empty($data)) {
             $response = $this->cloudSyncClient->upload($jobId, $data, $startTime, false);
 
@@ -203,6 +222,7 @@ class SynchronizationService
                 $this->incrementalSyncRepository->removeIncrementalSyncObjects($shopContent, array_column($contentsToSync, 'id'), $langIso);
             }
         } else {
+            HttpClient::traceLog('sendIncrementalSync skip upload: data empty');
             $this->incrementalSyncRepository->removeIncrementalSyncObjects($shopContent, array_column($contentsToSync, 'id'), $langIso);
         }
 

--- a/src/Service/SynchronizationService.php
+++ b/src/Service/SynchronizationService.php
@@ -133,7 +133,7 @@ class SynchronizationService
         HttpClient::traceLog(sprintf(
             'sendFullSync shopContent=%s rows=%d offset=%d limit=%d',
             $shopContent,
-            is_array($data) ? count($data) : 0,
+            count($data),
             $offset,
             $limit
         ));
@@ -210,7 +210,7 @@ class SynchronizationService
         HttpClient::traceLog(sprintf(
             'sendIncrementalSync shopContent=%s rows=%d upserts=%d deletes=%d',
             $shopContent,
-            is_array($data) ? count($data) : 0,
+            count($data),
             count($upsertedContents),
             count($deletedContents)
         ));


### PR DESCRIPTION
Adds a self-contained tracing mechanism for ps_eventbus, gated by PrestaShop debug mode (`_PS_MODE_DEV_`). No behavioural change in prod zips.

## What it logs

Each line lands in `trace-YYYY-MM-DD.log` at the module root (rotates per day).

- **Inbound** — every hit to `apiHealthCheck` / `apiShopContent`: method, URI, remote IP, Authorization presence, content-type, UA, body (500B).
- **Outbound** — every cURL request from `HttpClient::exec`: target URL, response status, body (500B).
- **CloudSync upload** — `jobId`, `shopId`, item count, fullSync flag, target URL.
- **Sync pipeline** — `handleDataSync` entry, `authorize()` result, `sendFullSync` / `sendIncrementalSync` branch + row count, "skip upload: data empty" reason.

## Gate

`HttpClient::isTraceEnabled()` returns `defined('_PS_MODE_DEV_') && _PS_MODE_DEV_`. Helpers no-op when off, so prod zips ship with the helpers compiled in but silent.

## e2e production profile

`e2e-env/docker-compose.yml`:
- New `production` profile with `prestashop-prod` + `cloudflared-prod` services that mount `.config.prod.php` over `config.php`, exposing the shop via the Cloudflare tunnel for real ps-accounts.
- `prestashop-prod` carries `DEBUG_MODE=true` so flashlight flips `_PS_MODE_DEV_` on boot (the shared `prestashop-base` env was being silently overridden by service-level env lists).
- `cloudsync-mock` and `reverse-proxy` constrained to non-production profiles.
- Dev placeholder version bumped from `0.0.0` to `4.0.0` in `ps_eventbus.php` / `config.xml` so CloudSync routes to `apiShopContent` when mounted from raw source. Makefile's `replace_version` still rewrites this at zip-build from the git tag, so prod zips are unaffected.

## Test plan
- [x] PHP lint on all touched files.
- [x] e2e: `_PS_MODE_DEV_=false` → trace file not created.
- [x] e2e: `DEBUG_MODE=true` flips `_PS_MODE_DEV_=true` → trace file written.
- [x] e2e: full sync triggered via orchestrator CLI → expected sequence of inbound/outbound/upload/branch lines.
- [x] Sonar (no new issues since the trace helper extraction in `handleDataSync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)