### PR TITLE
fix: ps_accounts v8 hydra-token compatibility + empty-jobId guard

### DIFF
--- a/src/Service/ApiAuthorizationService.php
+++ b/src/Service/ApiAuthorizationService.php
@@ -125,20 +125,14 @@ class ApiAuthorizationService
         }
 
         // Check if the job already exists
-        $job = $this->syncRepository->findJobById($jobId);
-
-        if ($job) {
+        if ($this->syncRepository->findJobById($jobId)) {
             return true;
         }
 
         // Check the jobId validity to avoid Denial Of Service
         $jobValidationResponse = $this->cloudSyncClient->validateJobId($jobId);
 
-        if ((int) $jobValidationResponse['httpCode'] !== 201) {
-            return false;
-        }
-
-        // Cache the valid jobId
-        return $this->syncRepository->insertJob($jobId, date(DATE_ATOM));
+        return (int) $jobValidationResponse['httpCode'] === 201
+            && $this->syncRepository->insertJob($jobId, date(DATE_ATOM));
     }
 }

--- a/src/Service/ApiAuthorizationService.php
+++ b/src/Service/ApiAuthorizationService.php
@@ -120,6 +120,10 @@ class ApiAuthorizationService
      */
     private function authorizeCall($jobId)
     {
+        if (empty($jobId)) {
+            return false;
+        }
+
         // Check if the job already exists
         $job = $this->syncRepository->findJobById($jobId);
 

--- a/src/Service/ApiHealthCheckService.php
+++ b/src/Service/ApiHealthCheckService.php
@@ -187,7 +187,7 @@ class ApiHealthCheckService
      * via JWKS (Validator). Older versions emit firebase tokens validated via
      * the legacy /v1/shop/token/verify endpoint (AccountsClient, deprecated v8).
      *
-     * @param \Module|false $psAccount
+     * @param \ModuleCore|false $psAccount
      * @param string $token
      *
      * @return bool
@@ -198,26 +198,21 @@ class ApiHealthCheckService
             return false;
         }
 
-        if (version_compare($psAccount->version, '8.0.0', '>=')) {
-            try {
-                /** @var Validator $validator */
-                /** @phpstan-ignore-next-line */
-                $validator = $psAccount->getService(Validator::class);
-                $validator->verifyToken($token);
-
-                return true;
-            } catch (\Exception $e) {
-                $this->errorHandler->handle($e, true);
-
-                return false;
-            }
-        }
-
-        /* @phpstan-ignore-next-line */
-        $accountsClient = $psAccount->getService(AccountsClient::class);
+        $isV8 = version_compare($psAccount->version, '8.0.0', '>=');
         /** @phpstan-ignore-next-line */
-        $response = $accountsClient->verifyToken($token);
+        $serviceClass = $isV8 ? Validator::class : AccountsClient::class;
 
-        return $response && true === $response['status'];
+        try {
+            /** @phpstan-ignore-next-line */
+            $service = $psAccount->getService($serviceClass);
+            /** @phpstan-ignore-next-line */
+            $response = $service->verifyToken($token);
+
+            return $isV8 || ($response && true === $response['status']);
+        } catch (\Exception $e) {
+            $this->errorHandler->handle($e, true);
+
+            return false;
+        }
     }
 }

--- a/src/Service/ApiHealthCheckService.php
+++ b/src/Service/ApiHealthCheckService.php
@@ -28,6 +28,7 @@
 namespace PrestaShop\Module\PsEventbus\Service;
 
 use PrestaShop\Module\PsAccounts\Api\Client\AccountsClient;
+use PrestaShop\Module\PsAccounts\Service\OAuth2\Token\Validator\Validator;
 use PrestaShop\Module\PsEventbus\Handler\ErrorHandler\ErrorHandler;
 
 if (!defined('_PS_VERSION_')) {
@@ -107,17 +108,8 @@ class ApiHealthCheckService
             $token = $this->psAccountsAdapterService->getShopToken();
             if ($token) {
                 $psAccount = \Module::getInstanceByName('ps_accounts');
-
-                /* @phpstan-ignore-next-line */
-                $accountsClient = $psAccount->getService(AccountsClient::class);
-
                 $tokenIsSet = true;
-
-                /** @phpstan-ignore-next-line */
-                $response = $accountsClient->verifyToken($token);
-                if ($response && true === $response['status']) {
-                    $tokenValid = true;
-                }
+                $tokenValid = $this->verifyShopToken($psAccount, $token);
             }
         } catch (\Exception $exception) {
             $this->errorHandler->handle($exception);
@@ -188,5 +180,44 @@ class ApiHealthCheckService
 
         // return array<string>, with list of missing required table
         return array_diff(self::REQUIRED_TABLES, $filteredRequiredTables);
+    }
+
+    /**
+     * Verify a shop token. ps_accounts v8+ emits hydra tokens validated locally
+     * via JWKS (Validator). Older versions emit firebase tokens validated via
+     * the legacy /v1/shop/token/verify endpoint (AccountsClient, deprecated v8).
+     *
+     * @param \Module|false $psAccount
+     * @param string $token
+     *
+     * @return bool
+     */
+    private function verifyShopToken($psAccount, $token)
+    {
+        if (!$psAccount) {
+            return false;
+        }
+
+        if (version_compare($psAccount->version, '8.0.0', '>=')) {
+            try {
+                /** @var Validator $validator */
+                /** @phpstan-ignore-next-line */
+                $validator = $psAccount->getService(Validator::class);
+                $validator->verifyToken($token);
+
+                return true;
+            } catch (\Exception $e) {
+                $this->errorHandler->handle($e, true);
+
+                return false;
+            }
+        }
+
+        /* @phpstan-ignore-next-line */
+        $accountsClient = $psAccount->getService(AccountsClient::class);
+        /** @phpstan-ignore-next-line */
+        $response = $accountsClient->verifyToken($token);
+
+        return $response && true === $response['status'];
     }
 }


### PR DESCRIPTION
Two real bugs surfaced while exercising the module against real CloudSync prod with a ps_accounts v8.0.13 shop.

## fix: verify shop token locally on ps_accounts v8+ (hydra JWKS)

ps_accounts v8 changed `getShopToken()` to emit hydra (OAuth2) tokens issued by `oauth.prestashop.com`. `AccountsClient::verifyToken` (deprecated since v8.0.0) still hits the legacy `/v1/shop/token/verify` endpoint, which only validates firebase tokens and rejects hydra with `400 "Token is invalid"`.

Net effect on `main`: every healthcheck on a ps_accounts 8.x shop returns `is_valid_jwt: false`. CloudSync's orchestrator interprets that as `ShopHealthCheckInvalidAuthException` → never triggers `apiShopContent` → sync silently never runs.

Fix in `ApiHealthCheckService::verifyShopToken`:
- on `ps_accounts >= 8.0.0`, use the local JWKS-based `Validator` (`PrestaShop\Module\PsAccounts\Service\OAuth2\Token\Validator\Validator`) shipped by v8 — matches the hydra issuer;
- keep the legacy `AccountsClient::verifyToken` path for older ps_accounts versions still emitting firebase tokens.

ps_accounts module stays the single source of truth for which token type it issues — we just pick the matching verifier.

## fix: skip CloudSync job validation when jobId is empty

CloudSync sends an anonymous healthcheck probe (no `job_id` query). The shop was forwarding the empty string straight to `eventbus-sync.../job/`, which the upstream gRPC method rejects with `404 "Method does not exist."` Short-circuit in `ApiAuthorizationService::authorizeCall`.

Also collapsed `authorizeCall` to 3 returns to keep sonar `php:S1142` happy.

## Test plan
- [x] PHP lint on touched files.
- [x] Real shop, ps_accounts 8.0.13: before fix `is_valid_jwt: false`; after fix `is_valid_jwt: true` via JWKS validation.
- [x] Anonymous healthcheck probe: no longer triggers an outbound `GET /job/` 404.
- [x] Full sync via orchestrator CLI: outbound to `eventbus-proxy.psessentials.net/upload/<jobId>` reaches the service (no auth-level abort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)