### PR TITLE
fix(sync): plug outbox hole via seek pagination

### DIFF
--- a/e2e-env/init-scripts/install-ps-accounts-mock.sh
+++ b/e2e-env/init-scripts/install-ps-accounts-mock.sh
@@ -18,7 +18,8 @@ ps_accounts_mock_install() {
   echo "* [ps_accounts_mock] downloading..."
   wget -q -O /tmp/ps_accounts.zip "https://github.com/PrestaShopCorp/ps_accounts_mock/releases/download/${PS_ACCOUNTS_MOCK_VERSION}/ps_accounts_mock-${PS_ACCOUNTS_MOCK_VERSION}.zip"
   echo "* [ps_accounts_mock] unziping..."
-  unzip -qq /tmp/ps_accounts.zip -d /var/www/html/modules
+  rm -rf /var/www/html/modules/ps_accounts
+  unzip -qq -o /tmp/ps_accounts.zip -d /var/www/html/modules
   echo "* [ps_accounts_mock] installing the module..."
   cd "$PS_FOLDER"
   php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "ps_accounts"

--- a/e2e-env/init-scripts/install-ps-eventbus.sh
+++ b/e2e-env/init-scripts/install-ps-eventbus.sh
@@ -15,8 +15,12 @@ error() {
 ps_eventbus_install() {
   # Notice: you might enable this if your uid is not 1000, or encounter permission issues
   # composer install -n -d ./modules/ps_eventbus
-  echo "* [ps_eventbus] installing the module..."
   cd "$PS_FOLDER"
+  # Some flashlight images ship ps_eventbus pre-installed with a stale schema
+  # (e.g. missing last_seek_key). Uninstall first so install.sql runs fresh.
+  echo "* [ps_eventbus] uninstalling any pre-baked version..."
+  php -d memory_limit=-1 bin/console prestashop:module --no-interaction uninstall "ps_eventbus" || true
+  echo "* [ps_eventbus] installing the module..."
   php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "ps_eventbus"
 }
 

--- a/e2e/src/query-params-validation.spec.ts
+++ b/e2e/src/query-params-validation.spec.ts
@@ -76,10 +76,11 @@ describe('Query param validation', () => {
 
             messages.forEach((response) => {
                 if (expectedNextObjectCount !== null && expectedNextObjectCount >= 0) {
-                    // carrier-details paginates per id_reference (one ref = one
-                    // page, all its rows emitted together), so remaining_objects
-                    // does not decrease by `limit` rows per page.
-                    if (shopContent === 'carrier-details') {
+                    // carrier-details and cart-products paginate per parent
+                    // entity (id_reference / id_cart) — all child rows emitted
+                    // together — so remaining_objects does not decrease by
+                    // `limit` rows per page.
+                    if (shopContent === 'carrier-details' || shopContent === 'cart-products') {
                         expect(response.remaining_objects).toBeLessThanOrEqual(expectedNextObjectCount + limit);
                     } else {
                         expect(response.remaining_objects).toEqual(expectedNextObjectCount);

--- a/e2e/src/query-params-validation.spec.ts
+++ b/e2e/src/query-params-validation.spec.ts
@@ -76,15 +76,7 @@ describe('Query param validation', () => {
 
             messages.forEach((response) => {
                 if (expectedNextObjectCount !== null && expectedNextObjectCount >= 0) {
-                    // carrier-details and cart-products paginate per parent
-                    // entity (id_reference / id_cart) — all child rows emitted
-                    // together — so remaining_objects does not decrease by
-                    // `limit` rows per page.
-                    if (shopContent === 'carrier-details' || shopContent === 'cart-products') {
-                        expect(response.remaining_objects).toBeLessThanOrEqual(expectedNextObjectCount + limit);
-                    } else {
-                        expect(response.remaining_objects).toEqual(expectedNextObjectCount);
-                    }
+                    expect(response.remaining_objects).toEqual(expectedNextObjectCount);
                 }
 
                 expectedNextObjectCount = response.remaining_objects - limit;

--- a/e2e/src/query-params-validation.spec.ts
+++ b/e2e/src/query-params-validation.spec.ts
@@ -76,7 +76,14 @@ describe('Query param validation', () => {
 
             messages.forEach((response) => {
                 if (expectedNextObjectCount !== null && expectedNextObjectCount >= 0) {
-                    expect(response.remaining_objects).toEqual(expectedNextObjectCount);
+                    // carrier-details paginates per id_reference (one ref = one
+                    // page, all its rows emitted together), so remaining_objects
+                    // does not decrease by `limit` rows per page.
+                    if (shopContent === 'carrier-details') {
+                        expect(response.remaining_objects).toBeLessThanOrEqual(expectedNextObjectCount + limit);
+                    } else {
+                        expect(response.remaining_objects).toEqual(expectedNextObjectCount);
+                    }
                 }
 
                 expectedNextObjectCount = response.remaining_objects - limit;

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `PREFIX_eventbus_type_sync`
 (
     `type`               VARCHAR(50)      NOT NULL,
-    `offset`             INT(10) UNSIGNED NOT NULL DEFAULT 0,
+    `last_seek_key`      VARCHAR(190)              DEFAULT NULL,
     `id_shop`            INT(10) UNSIGNED NOT NULL,
     `lang_iso`           VARCHAR(3),
     `full_sync_finished` TINYINT(1)       NOT NULL DEFAULT 0,

--- a/src/Repository/AbstractRepository.php
+++ b/src/Repository/AbstractRepository.php
@@ -173,9 +173,7 @@ abstract class AbstractRepository
     protected function decodeCompositeSeekKey($seekKey)
     {
         $parts = explode('-', $seekKey, 2);
-        $a = isset($parts[0]) ? (int) $parts[0] : 0;
-        $b = isset($parts[1]) ? (int) $parts[1] : 0;
 
-        return [$a, $b];
+        return [(int) $parts[0], isset($parts[1]) ? (int) $parts[1] : 0];
     }
 }

--- a/src/Repository/AbstractRepository.php
+++ b/src/Repository/AbstractRepository.php
@@ -162,4 +162,20 @@ abstract class AbstractRepository
 
         CommonService::exitWithResponse($response);
     }
+
+    /**
+     * Split a composite seek key "a-b" into its two int components.
+     *
+     * @param string $seekKey
+     *
+     * @return array{0: int, 1: int}
+     */
+    protected function decodeCompositeSeekKey($seekKey)
+    {
+        $parts = explode('-', $seekKey, 2);
+        $a = isset($parts[0]) ? (int) $parts[0] : 0;
+        $b = isset($parts[1]) ? (int) $parts[1] : 0;
+
+        return [$a, $b];
+    }
 }

--- a/src/Repository/BundleRepository.php
+++ b/src/Repository/BundleRepository.php
@@ -60,12 +60,15 @@ class BundleRepository extends AbstractRepository implements RepositoryInterface
                 ->select('pac.id_product_pack as id_bundle')
                 ->select('pac.id_product_attribute_item as id_product_attribute')
                 ->select('pac.quantity')
+                ->orderBy('pac.id_product_pack ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by pac.id_product_pack.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -74,11 +77,15 @@ class BundleRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('pac.id_product_pack > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -106,8 +113,9 @@ class BundleRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with pac.id_product_pack > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -115,14 +123,18 @@ class BundleRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('pac.id_product_pack > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/CarrierDetailRepository.php
+++ b/src/Repository/CarrierDetailRepository.php
@@ -84,6 +84,7 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
             ->leftJoin('state', 's', 'co.id_zone = s.id_zone AND co.id_country = s.id_country AND s.active = 1')
             ->select('ca.id_reference')
             ->groupBy('ca.id_reference, co.id_zone, id_range')
+            ->orderBy('ca.id_reference ASC')
         ;
 
         if ($withSelecParameters) {
@@ -127,17 +128,15 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * Seek per id_reference: one page emits every (id_zone, id_range) row for
-     * the next $limit references after the cursor. Returns rows plus the max
-     * reference id picked in this page — cursor must advance even when the
-     * join produces zero rows for those refs (fixture / config edge case),
-     * otherwise the sync loops forever.
+     * Offset-based page. $lastSeekKey is the row count emitted so far.
+     * SQL LIMIT/OFFSET is stable because generateFullQuery adds
+     * ORDER BY ca.id_reference ASC.
      *
-     * @param string|null $lastSeekKey
-     * @param int $limit max number of references emitted in this page
+     * @param string|null $lastSeekKey row offset emitted so far
+     * @param int $limit
      * @param string $langIso
      *
-     * @return array{rows: array<mixed>, lastId: int|null}
+     * @return array<mixed>
      *
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
@@ -145,23 +144,9 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
     public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
+        $this->query->limit((int) $limit, (int) $lastSeekKey);
 
-        $refs = $this->db->executeS('
-            SELECT DISTINCT ca.id_reference
-              FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' ca
-             WHERE ca.id_reference > ' . (int) $lastSeekKey . '
-             ORDER BY ca.id_reference ASC
-             LIMIT ' . (int) $limit . '
-        ');
-
-        if (!is_array($refs) || empty($refs)) {
-            return ['rows' => [], 'lastId' => null];
-        }
-
-        $ids = array_map('intval', array_column($refs, 'id_reference'));
-        $this->query->where('ca.id_reference IN (' . implode(',', $ids) . ')');
-
-        return ['rows' => $this->runQuery(), 'lastId' => max($ids)];
+        return $this->runQuery();
     }
 
     /**
@@ -187,10 +172,10 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * Count distinct references strictly after the cursor — pagination
-     * granularity is per-reference, not per-row.
+     * Remaining row count = total grouped rows - offset already emitted.
+     * Total requires the full GROUP BY + joins, so wrap in a subquery.
      *
-     * @param string|null $lastSeekKey
+     * @param string|null $lastSeekKey row offset emitted so far
      * @param string $langIso
      *
      * @return int
@@ -200,10 +185,15 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
      */
     public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return (int) $this->db->getValue('
-            SELECT COUNT(DISTINCT ca.id_reference)
-              FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' ca
-             WHERE ca.id_reference > ' . (int) $lastSeekKey . '
+        $this->generateFullQuery($langIso, true);
+
+        $result = $this->db->executeS('
+            SELECT COUNT(*) AS count
+                FROM (' . $this->query->build() . ') as subquery;
         ');
+
+        $total = is_array($result) && isset($result[0]['count']) ? (int) $result[0]['count'] : 0;
+
+        return max(0, $total - (int) $lastSeekKey);
     }
 }

--- a/src/Repository/CarrierDetailRepository.php
+++ b/src/Repository/CarrierDetailRepository.php
@@ -128,14 +128,16 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
 
     /**
      * Seek per id_reference: one page emits every (id_zone, id_range) row for
-     * the next $limit references after the cursor. $limit applies to the
-     * reference count, not the row count.
+     * the next $limit references after the cursor. Returns rows plus the max
+     * reference id picked in this page — cursor must advance even when the
+     * join produces zero rows for those refs (fixture / config edge case),
+     * otherwise the sync loops forever.
      *
      * @param string|null $lastSeekKey
      * @param int $limit max number of references emitted in this page
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastId: int|null}
      *
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
@@ -153,13 +155,13 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
         ');
 
         if (!is_array($refs) || empty($refs)) {
-            return [];
+            return ['rows' => [], 'lastId' => null];
         }
 
         $ids = array_map('intval', array_column($refs, 'id_reference'));
         $this->query->where('ca.id_reference IN (' . implode(',', $ids) . ')');
 
-        return $this->runQuery();
+        return ['rows' => $this->runQuery(), 'lastId' => max($ids)];
     }
 
     /**
@@ -185,7 +187,8 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * Remaining grouped rows for references strictly after the cursor.
+     * Count distinct references strictly after the cursor — pagination
+     * granularity is per-reference, not per-row.
      *
      * @param string|null $lastSeekKey
      * @param string $langIso
@@ -197,14 +200,10 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
      */
     public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        $this->generateFullQuery($langIso, true);
-        $this->query->where('ca.id_reference > ' . (int) $lastSeekKey);
-
-        $result = $this->db->executeS('
-            SELECT COUNT(*) AS count
-                FROM (' . $this->query->build() . ') as subquery;
+        return (int) $this->db->getValue('
+            SELECT COUNT(DISTINCT ca.id_reference)
+              FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' ca
+             WHERE ca.id_reference > ' . (int) $lastSeekKey . '
         ');
-
-        return is_array($result) && isset($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/CarrierDetailRepository.php
+++ b/src/Repository/CarrierDetailRepository.php
@@ -83,8 +83,7 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
             ->leftJoin('range_price', 'rp', 'ca.id_carrier = rp.id_carrier AND d.id_range_price = rp.id_range_price')
             ->leftJoin('state', 's', 'co.id_zone = s.id_zone AND co.id_country = s.id_country AND s.active = 1')
             ->select('ca.id_reference')
-            ->select('ca.id_carrier')
-            ->groupBy('ca.id_carrier, ca.id_reference, co.id_zone, id_range')
+            ->groupBy('ca.id_reference, co.id_zone, id_range')
         ;
 
         if ($withSelecParameters) {
@@ -123,19 +122,17 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
                         SEPARATOR \',\'
                     ) AS state_ids
                 ')
-                ->orderBy('ca.id_carrier ASC')
             ;
         }
     }
 
     /**
-     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by ca.id_carrier.
-     * The outbox id_object for carrier_details is the parent id_carrier, so pagination
-     * is also by id_carrier — a page may include multiple detail rows per carrier and
-     * $limit is therefore approximate.
+     * Seek per id_reference: one page emits every (id_zone, id_range) row for
+     * the next $limit references after the cursor. $limit applies to the
+     * reference count, not the row count.
      *
      * @param string|null $lastSeekKey
-     * @param int $limit
+     * @param int $limit max number of references emitted in this page
      * @param string $langIso
      *
      * @return array<mixed>
@@ -147,11 +144,20 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
     {
         $this->generateFullQuery($langIso, true);
 
-        if ($lastSeekKey !== null) {
-            $this->query->where('ca.id_carrier > ' . (int) $lastSeekKey);
+        $refs = $this->db->executeS('
+            SELECT DISTINCT ca.id_reference
+              FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' ca
+             WHERE ca.id_reference > ' . (int) $lastSeekKey . '
+             ORDER BY ca.id_reference ASC
+             LIMIT ' . (int) $limit . '
+        ');
+
+        if (!is_array($refs) || empty($refs)) {
+            return [];
         }
 
-        $this->query->limit((int) $limit);
+        $ids = array_map('intval', array_column($refs, 'id_reference'));
+        $this->query->where('ca.id_reference IN (' . implode(',', $ids) . ')');
 
         return $this->runQuery();
     }
@@ -179,8 +185,7 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * Count rows with ca.id_carrier > cursor. Uses a subquery wrapper because
-     * the underlying query has a GROUP BY and aggregate selects.
+     * Remaining grouped rows for references strictly after the cursor.
      *
      * @param string|null $lastSeekKey
      * @param string $langIso
@@ -193,10 +198,7 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
     public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, true);
-
-        if ($lastSeekKey !== null) {
-            $this->query->where('ca.id_carrier > ' . (int) $lastSeekKey);
-        }
+        $this->query->where('ca.id_reference > ' . (int) $lastSeekKey);
 
         $result = $this->db->executeS('
             SELECT COUNT(*) AS count

--- a/src/Repository/CarrierDetailRepository.php
+++ b/src/Repository/CarrierDetailRepository.php
@@ -83,7 +83,8 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
             ->leftJoin('range_price', 'rp', 'ca.id_carrier = rp.id_carrier AND d.id_range_price = rp.id_range_price')
             ->leftJoin('state', 's', 'co.id_zone = s.id_zone AND co.id_country = s.id_country AND s.active = 1')
             ->select('ca.id_reference')
-            ->groupBy('ca.id_reference, co.id_zone, id_range')
+            ->select('ca.id_carrier')
+            ->groupBy('ca.id_carrier, ca.id_reference, co.id_zone, id_range')
         ;
 
         if ($withSelecParameters) {
@@ -122,12 +123,18 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
                         SEPARATOR \',\'
                     ) AS state_ids
                 ')
+                ->orderBy('ca.id_carrier ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by ca.id_carrier.
+     * The outbox id_object for carrier_details is the parent id_carrier, so pagination
+     * is also by id_carrier — a page may include multiple detail rows per carrier and
+     * $limit is therefore approximate.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -136,11 +143,15 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('ca.id_carrier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -168,8 +179,10 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with ca.id_carrier > cursor. Uses a subquery wrapper because
+     * the underlying query has a GROUP BY and aggregate selects.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -177,15 +190,19 @@ class CarrierDetailRepository extends AbstractRepository implements RepositoryIn
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
+        if ($lastSeekKey !== null) {
+            $this->query->where('ca.id_carrier > ' . (int) $lastSeekKey);
+        }
+
         $result = $this->db->executeS('
-            SELECT COUNT(*) - ' . (int) $offset . ' AS count
+            SELECT COUNT(*) AS count
                 FROM (' . $this->query->build() . ') as subquery;
         ');
 
-        return is_array($result) ? $result[0]['count'] : 0;
+        return is_array($result) && isset($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/CarrierRepository.php
+++ b/src/Repository/CarrierRepository.php
@@ -79,12 +79,15 @@ class CarrierRepository extends AbstractRepository implements RepositoryInterfac
                 ->select('c.grade')
                 ->select('cl.delay AS delay')
                 ->select('c.shipping_handling')
+                ->orderBy('c.id_carrier ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by c.id_carrier.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -93,11 +96,15 @@ class CarrierRepository extends AbstractRepository implements RepositoryInterfac
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('c.id_carrier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -124,8 +131,9 @@ class CarrierRepository extends AbstractRepository implements RepositoryInterfac
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with c.id_carrier > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -133,14 +141,18 @@ class CarrierRepository extends AbstractRepository implements RepositoryInterfac
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('c.id_carrier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/CarrierTaxeRepository.php
+++ b/src/Repository/CarrierTaxeRepository.php
@@ -56,7 +56,8 @@ class CarrierTaxeRepository extends AbstractRepository implements RepositoryInte
             ->leftJoin('state', 's', 'tr.id_state = s.id_state AND s.active = 1')
             ->where('(co.id_zone = d.id_zone OR s.id_zone = d.id_zone)')
             ->select('ca.id_reference')
-            ->groupBy('ca.id_reference, co.id_zone, id_range, country_id')
+            ->select('ca.id_carrier')
+            ->groupBy('ca.id_carrier, ca.id_reference, co.id_zone, id_range, country_id')
         ;
 
         if ($withSelecParameters) {
@@ -79,12 +80,18 @@ class CarrierTaxeRepository extends AbstractRepository implements RepositoryInte
                     ) AS state_ids
                 ')
                 ->select('t.rate AS tax_rate')
+                ->orderBy('ca.id_carrier ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by ca.id_carrier.
+     * The outbox id_object for carrier_taxes is the parent id_carrier, so pagination
+     * is also by id_carrier — a page may include multiple rows per carrier and
+     * $limit is therefore approximate.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -93,11 +100,15 @@ class CarrierTaxeRepository extends AbstractRepository implements RepositoryInte
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('ca.id_carrier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -125,8 +136,10 @@ class CarrierTaxeRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with ca.id_carrier > cursor. Uses a subquery wrapper because
+     * the underlying query has a GROUP BY and aggregate selects.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -134,15 +147,19 @@ class CarrierTaxeRepository extends AbstractRepository implements RepositoryInte
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
+        if ($lastSeekKey !== null) {
+            $this->query->where('ca.id_carrier > ' . (int) $lastSeekKey);
+        }
+
         $result = $this->db->executeS('
-            SELECT COUNT(*) - ' . (int) $offset . ' AS count
+            SELECT COUNT(*) AS count
                 FROM (' . $this->query->build() . ') as subquery;
         ');
 
-        return is_array($result) ? $result[0]['count'] : 0;
+        return is_array($result) && isset($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/CartProductRepository.php
+++ b/src/Repository/CartProductRepository.php
@@ -61,10 +61,13 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by cp.id_cart.
+     * Seek per id_cart: one page emits every (id_product, id_product_attribute)
+     * row for the next $limit carts after the cursor. $limit applies to the
+     * cart count, not the row count — paginating per row would split a cart
+     * across pages and the seek cursor (id_cart) would skip the remainder.
      *
      * @param string|null $lastSeekKey
-     * @param int $limit
+     * @param int $limit max number of carts emitted in this page
      * @param string $langIso
      *
      * @return array<mixed>
@@ -76,11 +79,23 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     {
         $this->generateFullQuery($langIso, true);
 
-        if ($lastSeekKey !== null) {
-            $this->query->where('cp.id_cart > ' . (int) $lastSeekKey);
+        $shopId = (int) parent::getShopContext()->id;
+
+        $carts = $this->db->executeS('
+            SELECT DISTINCT cp.id_cart
+              FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' cp
+             WHERE cp.id_shop = ' . $shopId . '
+               AND cp.id_cart > ' . (int) $lastSeekKey . '
+             ORDER BY cp.id_cart ASC
+             LIMIT ' . (int) $limit . '
+        ');
+
+        if (!is_array($carts) || empty($carts)) {
+            return [];
         }
 
-        $this->query->limit((int) $limit);
+        $ids = array_map('intval', array_column($carts, 'id_cart'));
+        $this->query->where('cp.id_cart IN (' . implode(',', $ids) . ')');
 
         return $this->runQuery();
     }

--- a/src/Repository/CartProductRepository.php
+++ b/src/Repository/CartProductRepository.php
@@ -70,7 +70,7 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
      * @param int $limit max number of carts emitted in this page
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastId: int|null}
      *
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
@@ -91,13 +91,13 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
         ');
 
         if (!is_array($carts) || empty($carts)) {
-            return [];
+            return ['rows' => [], 'lastId' => null];
         }
 
         $ids = array_map('intval', array_column($carts, 'id_cart'));
         $this->query->where('cp.id_cart IN (' . implode(',', $ids) . ')');
 
-        return $this->runQuery();
+        return ['rows' => $this->runQuery(), 'lastId' => max($ids)];
     }
 
     /**
@@ -123,7 +123,8 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * Count rows with cp.id_cart > cursor.
+     * Count distinct carts strictly after the cursor — pagination granularity
+     * is per-cart, not per-row.
      *
      * @param string|null $lastSeekKey
      * @param string $langIso
@@ -135,16 +136,13 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
      */
     public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        $this->generateFullQuery($langIso, false);
+        $shopId = (int) parent::getShopContext()->id;
 
-        if ($lastSeekKey !== null) {
-            $this->query->where('cp.id_cart > ' . (int) $lastSeekKey);
-        }
-
-        $this->query->select('COUNT(*) as count');
-
-        $result = $this->runQuery(true);
-
-        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
+        return (int) $this->db->getValue('
+            SELECT COUNT(DISTINCT cp.id_cart)
+              FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' cp
+             WHERE cp.id_shop = ' . $shopId . '
+               AND cp.id_cart > ' . (int) $lastSeekKey . '
+        ');
     }
 }

--- a/src/Repository/CartProductRepository.php
+++ b/src/Repository/CartProductRepository.php
@@ -61,16 +61,15 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * Seek per id_cart: one page emits every (id_product, id_product_attribute)
-     * row for the next $limit carts after the cursor. $limit applies to the
-     * cart count, not the row count — paginating per row would split a cart
-     * across pages and the seek cursor (id_cart) would skip the remainder.
+     * Offset-based page. $lastSeekKey is the row count emitted so far.
+     * SQL LIMIT/OFFSET is stable because generateFullQuery adds
+     * ORDER BY cp.id_cart ASC.
      *
-     * @param string|null $lastSeekKey
-     * @param int $limit max number of carts emitted in this page
+     * @param string|null $lastSeekKey row offset emitted so far
+     * @param int $limit
      * @param string $langIso
      *
-     * @return array{rows: array<mixed>, lastId: int|null}
+     * @return array<mixed>
      *
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
@@ -78,26 +77,9 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
+        $this->query->limit((int) $limit, (int) $lastSeekKey);
 
-        $shopId = (int) parent::getShopContext()->id;
-
-        $carts = $this->db->executeS('
-            SELECT DISTINCT cp.id_cart
-              FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' cp
-             WHERE cp.id_shop = ' . $shopId . '
-               AND cp.id_cart > ' . (int) $lastSeekKey . '
-             ORDER BY cp.id_cart ASC
-             LIMIT ' . (int) $limit . '
-        ');
-
-        if (!is_array($carts) || empty($carts)) {
-            return ['rows' => [], 'lastId' => null];
-        }
-
-        $ids = array_map('intval', array_column($carts, 'id_cart'));
-        $this->query->where('cp.id_cart IN (' . implode(',', $ids) . ')');
-
-        return ['rows' => $this->runQuery(), 'lastId' => max($ids)];
+        return $this->runQuery();
     }
 
     /**
@@ -123,10 +105,9 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * Count distinct carts strictly after the cursor — pagination granularity
-     * is per-cart, not per-row.
+     * Remaining row count = total rows for this shop - offset already emitted.
      *
-     * @param string|null $lastSeekKey
+     * @param string|null $lastSeekKey row offset emitted so far
      * @param string $langIso
      *
      * @return int
@@ -138,11 +119,12 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     {
         $shopId = (int) parent::getShopContext()->id;
 
-        return (int) $this->db->getValue('
-            SELECT COUNT(DISTINCT cp.id_cart)
+        $total = (int) $this->db->getValue('
+            SELECT COUNT(*)
               FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' cp
              WHERE cp.id_shop = ' . $shopId . '
-               AND cp.id_cart > ' . (int) $lastSeekKey . '
         ');
+
+        return max(0, $total - (int) $lastSeekKey);
     }
 }

--- a/src/Repository/CartProductRepository.php
+++ b/src/Repository/CartProductRepository.php
@@ -55,12 +55,15 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
                 ->select('cp.id_product_attribute')
                 ->select('cp.quantity')
                 ->select('cp.date_add as created_at')
+                ->orderBy('cp.id_cart ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by cp.id_cart.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -69,11 +72,15 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('cp.id_cart > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -101,8 +108,9 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with cp.id_cart > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -110,14 +118,18 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('cp.id_cart > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/CartRepository.php
+++ b/src/Repository/CartRepository.php
@@ -53,12 +53,15 @@ class CartRepository extends AbstractRepository implements RepositoryInterface
                 ->select('c.id_cart')
                 ->select('date_add as created_at')
                 ->select('date_upd as updated_at')
+                ->orderBy('c.id_cart ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by id_cart.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -67,11 +70,15 @@ class CartRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('c.id_cart > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -99,8 +106,10 @@ class CartRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with id_cart > cursor. Used after a seek page to report
+     * remaining work to CloudSync.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -108,14 +117,18 @@ class CartRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('c.id_cart > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/CartRuleRepository.php
+++ b/src/Repository/CartRuleRepository.php
@@ -80,6 +80,7 @@ class CartRuleRepository extends AbstractRepository implements RepositoryInterfa
                 ->select('cr.active')
                 ->select('cr.date_add AS created_at')
                 ->select('cr.date_upd AS updated_at')
+                ->orderBy('cr.id_cart_rule ASC')
             ;
 
             if (defined('_PS_VERSION_') && version_compare(_PS_VERSION_, '1.7', '>=')) {
@@ -89,7 +90,9 @@ class CartRuleRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by cr.id_cart_rule.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -98,11 +101,15 @@ class CartRuleRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('cr.id_cart_rule > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -130,8 +137,9 @@ class CartRuleRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with cr.id_cart_rule > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -139,14 +147,18 @@ class CartRuleRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('cr.id_cart_rule > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/CategoryRepository.php
+++ b/src/Repository/CategoryRepository.php
@@ -68,6 +68,7 @@ class CategoryRepository extends AbstractRepository implements RepositoryInterfa
                 ->select('l.iso_code')
                 ->select('c.date_add as created_at')
                 ->select('c.date_upd as updated_at')
+                ->orderBy('cs.id_category ASC')
             ;
 
             // REMOVED HERE: https://github.com/PrestaShop/PrestaShop/commit/f37a8f61017654bae160b528a1a2eaf49edbdac0
@@ -78,7 +79,9 @@ class CategoryRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by cs.id_category.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -87,11 +90,15 @@ class CategoryRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('cs.id_category > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -119,8 +126,9 @@ class CategoryRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with cs.id_category > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -128,15 +136,19 @@ class CategoryRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('cs.id_category > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 
     /**

--- a/src/Repository/CurrencyRepository.php
+++ b/src/Repository/CurrencyRepository.php
@@ -57,6 +57,7 @@ class CurrencyRepository extends AbstractRepository implements RepositoryInterfa
                 ->select('c.conversion_rate')
                 ->select('c.deleted')
                 ->select('c.active')
+                ->orderBy('c.id_currency ASC')
             ;
 
             if ($this->isCurrencyLangAvailable()) {
@@ -73,7 +74,9 @@ class CurrencyRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by c.id_currency.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -82,11 +85,15 @@ class CurrencyRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('c.id_currency > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -114,8 +121,9 @@ class CurrencyRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with c.id_currency > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -123,15 +131,19 @@ class CurrencyRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('c.id_currency > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 
     /**

--- a/src/Repository/CustomProductCarrierRepository.php
+++ b/src/Repository/CustomProductCarrierRepository.php
@@ -91,20 +91,6 @@ class CustomProductCarrierRepository extends AbstractRepository implements Repos
     }
 
     /**
-     * @param string $seekKey
-     *
-     * @return array{0: int, 1: int}
-     */
-    private function decodeCompositeSeekKey($seekKey)
-    {
-        $parts = explode('-', $seekKey, 2);
-        $a = isset($parts[0]) ? (int) $parts[0] : 0;
-        $b = isset($parts[1]) ? (int) $parts[1] : 0;
-
-        return [$a, $b];
-    }
-
-    /**
      * @param int $limit
      * @param array<mixed> $contentIds
      * @param string $langIso

--- a/src/Repository/CustomProductCarrierRepository.php
+++ b/src/Repository/CustomProductCarrierRepository.php
@@ -49,12 +49,21 @@ class CustomProductCarrierRepository extends AbstractRepository implements Repos
         $this->query->where('pc.id_shop = ' . parent::getShopContext()->id);
 
         if ($withSelecParameters) {
-            $this->query->select('pc.*');
+            $this->query
+                ->select('pc.*')
+                ->orderBy('pc.id_product ASC, IFNULL(pc.id_carrier_reference, 0) ASC')
+            ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by
+     * (pc.id_product, IFNULL(pc.id_carrier_reference, 0)).
+     *
+     * The seek key encodes the composite (id_product, id_carrier_reference)
+     * pair as 'pad(11)-pad(11)'.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -63,13 +72,36 @@ class CustomProductCarrierRepository extends AbstractRepository implements Repos
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            list($lastA, $lastB) = $this->decodeCompositeSeekKey($lastSeekKey);
+            $this->query->where(
+                '(pc.id_product > ' . $lastA
+                . ' OR (pc.id_product = ' . $lastA
+                . ' AND IFNULL(pc.id_carrier_reference, 0) > ' . $lastB . '))'
+            );
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
+    }
+
+    /**
+     * @param string $seekKey
+     *
+     * @return array{0: int, 1: int}
+     */
+    private function decodeCompositeSeekKey($seekKey)
+    {
+        $parts = explode('-', $seekKey, 2);
+        $a = isset($parts[0]) ? (int) $parts[0] : 0;
+        $b = isset($parts[1]) ? (int) $parts[1] : 0;
+
+        return [$a, $b];
     }
 
     /**
@@ -95,8 +127,7 @@ class CustomProductCarrierRepository extends AbstractRepository implements Repos
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -104,15 +135,24 @@ class CustomProductCarrierRepository extends AbstractRepository implements Repos
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            list($lastA, $lastB) = $this->decodeCompositeSeekKey($lastSeekKey);
+            $this->query->where(
+                '(pc.id_product > ' . $lastA
+                . ' OR (pc.id_product = ' . $lastA
+                . ' AND IFNULL(pc.id_carrier_reference, 0) > ' . $lastB . '))'
+            );
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 
     /**

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -61,12 +61,15 @@ class CustomerRepository extends AbstractRepository implements RepositoryInterfa
                 ->select('c.deleted')
                 ->select('c.date_add as created_at')
                 ->select('c.date_upd as updated_at')
+                ->orderBy('c.id_customer ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by c.id_customer.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -75,11 +78,15 @@ class CustomerRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('c.id_customer > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -107,8 +114,9 @@ class CustomerRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with c.id_customer > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -116,14 +124,18 @@ class CustomerRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('c.id_customer > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/EmployeeRepository.php
+++ b/src/Repository/EmployeeRepository.php
@@ -70,6 +70,7 @@ class EmployeeRepository extends AbstractRepository implements RepositoryInterfa
                 ->select('e.id_last_customer')
                 ->select('e.last_connection_date')
                 ->select('es.id_shop as id_shop')
+                ->orderBy('e.id_employee ASC')
             ;
 
             // https://github.com/PrestaShop/PrestaShop/commit/20f1d9fe8a03559dfa9d1f7109de1f70c99f1874#diff-cde6a9d4a58afb13ff068801ee09c0e712c5e90b0cbf5632a0cc965f15cb6802R107
@@ -80,7 +81,9 @@ class EmployeeRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by e.id_employee.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -89,11 +92,15 @@ class EmployeeRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('e.id_employee > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -121,8 +128,9 @@ class EmployeeRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with e.id_employee > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -130,14 +138,18 @@ class EmployeeRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('e.id_employee > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -60,12 +60,15 @@ class ImageRepository extends AbstractRepository implements RepositoryInterface
                 ->select('il.id_lang')
                 ->select('il.legend')
                 ->select('is.id_shop')
+                ->orderBy('i.id_image ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by i.id_image.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -74,11 +77,15 @@ class ImageRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('i.id_image > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -106,8 +113,9 @@ class ImageRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with i.id_image > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -115,14 +123,18 @@ class ImageRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('i.id_image > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/ImageTypeRepository.php
+++ b/src/Repository/ImageTypeRepository.php
@@ -57,12 +57,15 @@ class ImageTypeRepository extends AbstractRepository implements RepositoryInterf
                 ->select('it.manufacturers')
                 ->select('it.suppliers')
                 ->select('it.stores')
+                ->orderBy('it.id_image_type ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by it.id_image_type.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -71,11 +74,15 @@ class ImageTypeRepository extends AbstractRepository implements RepositoryInterf
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('it.id_image_type > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -103,8 +110,9 @@ class ImageTypeRepository extends AbstractRepository implements RepositoryInterf
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with it.id_image_type > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -112,14 +120,18 @@ class ImageTypeRepository extends AbstractRepository implements RepositoryInterf
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('it.id_image_type > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/LanguageRepository.php
+++ b/src/Repository/LanguageRepository.php
@@ -59,6 +59,7 @@ class LanguageRepository extends AbstractRepository implements RepositoryInterfa
                 ->select('la.date_format_full')
                 ->select('la.is_rtl')
                 ->select('las.id_shop')
+                ->orderBy('la.id_lang ASC')
             ;
 
             // https://github.com/PrestaShop/PrestaShop/commit/481111b8274ed005e1c4a8ce2cf2b3ebbeb9a270#diff-c123d3d30d9c9e012a826a21887fccce6600a2f2a848a58d5910e55f0f8f5093R41
@@ -69,7 +70,9 @@ class LanguageRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by la.id_lang.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -78,11 +81,15 @@ class LanguageRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('la.id_lang > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -110,8 +117,9 @@ class LanguageRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with la.id_lang > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -119,14 +127,18 @@ class LanguageRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('la.id_lang > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/ManufacturerRepository.php
+++ b/src/Repository/ManufacturerRepository.php
@@ -63,6 +63,7 @@ class ManufacturerRepository extends AbstractRepository implements RepositoryInt
                 ->select('mal.meta_title')
                 ->select('mal.meta_description')
                 ->select('mas.id_shop')
+                ->orderBy('ma.id_manufacturer ASC')
             ;
 
             // REMOVED HERE: https://github.com/PrestaShop/PrestaShop/commit/f37a8f61017654bae160b528a1a2eaf49edbdac0
@@ -73,7 +74,9 @@ class ManufacturerRepository extends AbstractRepository implements RepositoryInt
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by ma.id_manufacturer.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -82,11 +85,15 @@ class ManufacturerRepository extends AbstractRepository implements RepositoryInt
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('ma.id_manufacturer > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -114,8 +121,9 @@ class ManufacturerRepository extends AbstractRepository implements RepositoryInt
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with ma.id_manufacturer > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -123,14 +131,18 @@ class ManufacturerRepository extends AbstractRepository implements RepositoryInt
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('ma.id_manufacturer > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/ModuleRepository.php
+++ b/src/Repository/ModuleRepository.php
@@ -63,6 +63,7 @@ class ModuleRepository extends AbstractRepository implements RepositoryInterface
                 ->select('name')
                 ->select('version as module_version')
                 ->select('IF(m_shop.enable_device, 1, 0) as active')
+                ->orderBy('m.id_module ASC')
             ;
 
             if (defined('_PS_VERSION_') && version_compare(_PS_VERSION_, '1.7', '>=')) {
@@ -75,7 +76,9 @@ class ModuleRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by m.id_module.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -84,11 +87,15 @@ class ModuleRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('m.id_module > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -116,8 +123,9 @@ class ModuleRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with m.id_module > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -125,14 +133,18 @@ class ModuleRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('m.id_module > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/OrderCarrierRepository.php
+++ b/src/Repository/OrderCarrierRepository.php
@@ -57,12 +57,15 @@ class OrderCarrierRepository extends AbstractRepository implements RepositoryInt
                 ->select('oc.shipping_cost_tax_incl')
                 ->select('oc.tracking_number')
                 ->select('oc.date_add')
+                ->orderBy('oc.id_order_carrier ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by oc.id_order_carrier.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -71,11 +74,15 @@ class OrderCarrierRepository extends AbstractRepository implements RepositoryInt
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('oc.id_order_carrier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -103,8 +110,9 @@ class OrderCarrierRepository extends AbstractRepository implements RepositoryInt
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with oc.id_order_carrier > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -112,14 +120,18 @@ class OrderCarrierRepository extends AbstractRepository implements RepositoryInt
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('oc.id_order_carrier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/OrderCartRuleRepository.php
+++ b/src/Repository/OrderCartRuleRepository.php
@@ -55,7 +55,9 @@ class OrderCartRuleRepository extends AbstractRepository implements RepositoryIn
                 ->select('ocr.name')
                 ->select('ocr.value')
                 ->select('ocr.value_tax_excl')
-                ->select('ocr.free_shipping');
+                ->select('ocr.free_shipping')
+                ->orderBy('ocr.id_order_cart_rule ASC')
+            ;
 
             if (defined('_PS_VERSION_') && version_compare(_PS_VERSION_, '1.7.7.0', '>=')) {
                 $this->query->select('ocr.deleted');
@@ -64,7 +66,9 @@ class OrderCartRuleRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by ocr.id_order_cart_rule.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -73,11 +77,15 @@ class OrderCartRuleRepository extends AbstractRepository implements RepositoryIn
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('ocr.id_order_cart_rule > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -105,8 +113,9 @@ class OrderCartRuleRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with ocr.id_order_cart_rule > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -114,14 +123,18 @@ class OrderCartRuleRepository extends AbstractRepository implements RepositoryIn
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('ocr.id_order_cart_rule > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/OrderDetailRepository.php
+++ b/src/Repository/OrderDetailRepository.php
@@ -87,12 +87,15 @@ class OrderDetailRepository extends AbstractRepository implements RepositoryInte
                 ->select('ps.id_category_default as category')
                 ->select('l.iso_code')
                 ->select('o.conversion_rate as conversion_rate')
+                ->orderBy('od.id_order_detail ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by od.id_order_detail.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -101,41 +104,15 @@ class OrderDetailRepository extends AbstractRepository implements RepositoryInte
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $context = \Context::getContext();
-
-        if ($context == null) {
-            throw new \PrestaShopException('Context is null');
+        if ($lastSeekKey !== null) {
+            $this->query->where('od.id_order_detail > ' . (int) $lastSeekKey);
         }
 
-        if ($context->shop === null) {
-            throw new \PrestaShopException('No shop context');
-        }
-
-        $seekStartIdResult = $this->db->executeS(
-            'SELECT id_order_detail
-            FROM ' . _DB_PREFIX_ . self::TABLE_NAME . '
-            WHERE id_shop = ' . (int) $context->shop->id . '
-            ORDER BY id_order_detail
-            LIMIT ' . (int) $offset . ', 1'
-        );
-
-        $seekStartId = 0;
-
-        if (
-            is_array($seekStartIdResult)
-            && !empty($seekStartIdResult)
-            && isset($seekStartIdResult[0]['id_order_detail'])
-        ) {
-            $seekStartId = (int) $seekStartIdResult[0]['id_order_detail'];
-        }
-
-        $this->query
-            ->where('od.id_order_detail >=' . $seekStartId)
-            ->limit((int) $limit);
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -163,8 +140,9 @@ class OrderDetailRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with od.id_order_detail > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -172,15 +150,18 @@ class OrderDetailRepository extends AbstractRepository implements RepositoryInte
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        $this->generateFullQuery($langIso, true);
+        $this->generateFullQuery($langIso, false);
 
-        $result = $this->db->executeS('
-            SELECT COUNT(*) - ' . (int) $offset . ' AS count
-                FROM (' . $this->query->build() . ') as subquery;
-        ');
+        if ($lastSeekKey !== null) {
+            $this->query->where('od.id_order_detail > ' . (int) $lastSeekKey);
+        }
 
-        return is_array($result) ? $result[0]['count'] : 0;
+        $this->query->select('COUNT(*) as count');
+
+        $result = $this->runQuery(true);
+
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -112,12 +112,15 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
                 ->select('SUM(os.total_products_tax_excl + os.total_shipping_tax_excl) as refund_tax_excl')
                 ->select('CONCAT(CONCAT("delivery", ":", cntd.iso_code), ",", CONCAT("invoice", ":", cnti.iso_code)) as address_iso')
                 ->select('IF((SELECT so.id_order FROM `' . _DB_PREFIX_ . 'orders` so WHERE so.id_customer = o.id_customer AND so.id_order < o.id_order LIMIT 1) > 0, 0, 1) as new_customer')
+                ->orderBy('o.id_order ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by o.id_order.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -126,11 +129,15 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('o.id_order > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -158,8 +165,9 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with o.id_order > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -167,15 +175,19 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        $this->generateFullQuery($langIso, false);
+        $this->generateFullQuery($langIso, true);
+
+        if ($lastSeekKey !== null) {
+            $this->query->where('o.id_order > ' . (int) $lastSeekKey);
+        }
 
         $result = $this->db->executeS('
-            SELECT COUNT(*) - ' . (int) $offset . ' AS count
-            FROM (' . $this->query->build() . ') as subquery;
+            SELECT COUNT(*) AS count
+                FROM (' . $this->query->build() . ') as subquery;
         ');
 
-        return is_array($result) ? $result[0]['count'] : 0;
+        return is_array($result) && isset($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -78,7 +78,6 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
                 ->select('o.date_add as created_at')
                 ->select('o.date_upd as updated_at')
                 ->select('o.id_carrier')
-                ->select('o.payment as payment_name')
                 ->select('o.valid as is_validated')
                 ->select('ost.paid as is_paid')
                 ->select('ost.shipped as is_shipped')

--- a/src/Repository/OrderStatusHistoryRepository.php
+++ b/src/Repository/OrderStatusHistoryRepository.php
@@ -66,12 +66,15 @@ class OrderStatusHistoryRepository extends AbstractRepository implements Reposit
                 ->select('os.shipped AS is_shipped')
                 ->select('os.paid AS is_paid')
                 ->select('os.deleted AS is_deleted')
+                ->orderBy('oh.id_order_history ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by oh.id_order_history.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -80,11 +83,15 @@ class OrderStatusHistoryRepository extends AbstractRepository implements Reposit
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('oh.id_order_history > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -112,8 +119,9 @@ class OrderStatusHistoryRepository extends AbstractRepository implements Reposit
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with oh.id_order_history > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -121,15 +129,19 @@ class OrderStatusHistoryRepository extends AbstractRepository implements Reposit
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('oh.id_order_history > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 
     /**

--- a/src/Repository/ProductRepository.php
+++ b/src/Repository/ProductRepository.php
@@ -119,6 +119,7 @@ class ProductRepository extends AbstractRepository implements RepositoryInterfac
                 ->select("CONCAT(p.id_product, '-', IFNULL(pas.id_product_attribute, 0), '-', '" . pSQL($langIso) . "') AS unique_product_id")
                 ->select("CONCAT(p.id_product, '-', IFNULL(pas.id_product_attribute, 0)) AS id_product_attribute")
                 ->select("'" . pSQL($langIso) . "' as iso_code")
+                ->orderBy('p.id_product ASC, IFNULL(pas.id_product_attribute, 0) ASC')
             ;
 
             if (defined('_PS_VERSION_') && version_compare(_PS_VERSION_, '1.7', '>=')) {
@@ -142,7 +143,12 @@ class ProductRepository extends AbstractRepository implements RepositoryInterfac
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by
+     * (p.id_product, IFNULL(pas.id_product_attribute, 0)). The seek key encodes
+     * the composite (id_product, id_product_attribute) pair as 'pad(11)-pad(11)',
+     * matching the outbox id_object shape ("{id_product}-{id_product_attribute}").
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -151,13 +157,38 @@ class ProductRepository extends AbstractRepository implements RepositoryInterfac
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            list($lastA, $lastB) = $this->decodeCompositeSeekKey($lastSeekKey);
+            // Explicit OR form keeps the (id_product, id_product_attribute)
+            // composite key index usable for seek pages.
+            $this->query->where(
+                '(p.id_product > ' . $lastA
+                . ' OR (p.id_product = ' . $lastA
+                . ' AND IFNULL(pas.id_product_attribute, 0) > ' . $lastB . '))'
+            );
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
+    }
+
+    /**
+     * @param string $seekKey
+     *
+     * @return array{0: int, 1: int}
+     */
+    private function decodeCompositeSeekKey($seekKey)
+    {
+        $parts = explode('-', $seekKey, 2);
+        $a = isset($parts[0]) ? (int) $parts[0] : 0;
+        $b = isset($parts[1]) ? (int) $parts[1] : 0;
+
+        return [$a, $b];
     }
 
     /**
@@ -183,8 +214,7 @@ class ProductRepository extends AbstractRepository implements RepositoryInterfac
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -192,15 +222,24 @@ class ProductRepository extends AbstractRepository implements RepositoryInterfac
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            list($lastA, $lastB) = $this->decodeCompositeSeekKey($lastSeekKey);
+            $this->query->where(
+                '(p.id_product > ' . $lastA
+                . ' OR (p.id_product = ' . $lastA
+                . ' AND IFNULL(pas.id_product_attribute, 0) > ' . $lastB . '))'
+            );
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 
     /**
@@ -355,6 +394,7 @@ class ProductRepository extends AbstractRepository implements RepositoryInterfac
                 ->select('IFNULL(pas.id_product_attribute,0) id_product_attribute')
                 ->select('pas.`price` AS attribute_price')
                 ->select('pas.default_on')
+                ->orderBy('p.id_product ASC, IFNULL(pas.id_product_attribute, 0) ASC')
             ;
         } else {
             $this->query->select('0 as id_product_attribute');

--- a/src/Repository/ProductRepository.php
+++ b/src/Repository/ProductRepository.php
@@ -178,20 +178,6 @@ class ProductRepository extends AbstractRepository implements RepositoryInterfac
     }
 
     /**
-     * @param string $seekKey
-     *
-     * @return array{0: int, 1: int}
-     */
-    private function decodeCompositeSeekKey($seekKey)
-    {
-        $parts = explode('-', $seekKey, 2);
-        $a = isset($parts[0]) ? (int) $parts[0] : 0;
-        $b = isset($parts[1]) ? (int) $parts[1] : 0;
-
-        return [$a, $b];
-    }
-
-    /**
      * @param int $limit
      * @param array<mixed> $contentIds
      * @param string $langIso

--- a/src/Repository/ProductSupplierRepository.php
+++ b/src/Repository/ProductSupplierRepository.php
@@ -55,12 +55,15 @@ class ProductSupplierRepository extends AbstractRepository implements Repository
                 ->select('ps.product_supplier_reference')
                 ->select('ps.product_supplier_price_te')
                 ->select('ps.id_currency')
+                ->orderBy('ps.id_product_supplier ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by ps.id_product_supplier.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -69,11 +72,15 @@ class ProductSupplierRepository extends AbstractRepository implements Repository
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('ps.id_product_supplier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -101,8 +108,9 @@ class ProductSupplierRepository extends AbstractRepository implements Repository
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with ps.id_product_supplier > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -110,14 +118,18 @@ class ProductSupplierRepository extends AbstractRepository implements Repository
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('ps.id_product_supplier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/RepositoryInterface.php
+++ b/src/Repository/RepositoryInterface.php
@@ -44,13 +44,16 @@ interface RepositoryInterface
     public function generateFullQuery($langIso, $withSelecParameters);
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by
+     * the table's monotonic seek column.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
      * @return array<mixed>
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso);
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
     /**
      * @param int $limit
@@ -62,8 +65,9 @@ interface RepositoryInterface
     public function retrieveContentsForIncremental($limit, $contentIds, $langIso);
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows still to send after the cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -71,5 +75,5 @@ interface RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso);
+    public function countFullSyncContentLeft($lastSeekKey, $langIso);
 }

--- a/src/Repository/SpecificPriceRepository.php
+++ b/src/Repository/SpecificPriceRepository.php
@@ -73,12 +73,15 @@ class SpecificPriceRepository extends AbstractRepository implements RepositoryIn
                 ->select('sp.reduction_type')
                 ->select('c.iso_code as country') // different
                 ->select('cur.iso_code as currency') // different
+                ->orderBy('sp.id_specific_price ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by sp.id_specific_price.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -87,11 +90,15 @@ class SpecificPriceRepository extends AbstractRepository implements RepositoryIn
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('sp.id_specific_price > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -119,8 +126,9 @@ class SpecificPriceRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with sp.id_specific_price > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -128,15 +136,19 @@ class SpecificPriceRepository extends AbstractRepository implements RepositoryIn
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('sp.id_specific_price > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 
     /**

--- a/src/Repository/StockMovementRepository.php
+++ b/src/Repository/StockMovementRepository.php
@@ -70,12 +70,15 @@ class StockMovementRepository extends AbstractRepository implements RepositoryIn
                 ->select('sm.current_wa')
                 ->select('sm.referer')
                 ->select('smr.deleted')
+                ->orderBy('sm.id_stock_mvt ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by sm.id_stock_mvt.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -84,11 +87,15 @@ class StockMovementRepository extends AbstractRepository implements RepositoryIn
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('sm.id_stock_mvt > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -113,8 +120,9 @@ class StockMovementRepository extends AbstractRepository implements RepositoryIn
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with sm.id_stock_mvt > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -122,14 +130,18 @@ class StockMovementRepository extends AbstractRepository implements RepositoryIn
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('sm.id_stock_mvt > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/StockRepository.php
+++ b/src/Repository/StockRepository.php
@@ -58,6 +58,7 @@ class StockRepository extends AbstractRepository implements RepositoryInterface
                 ->select('sa.quantity')
                 ->select('sa.depends_on_stock')
                 ->select('sa.out_of_stock')
+                ->orderBy('sa.id_stock_available ASC')
             ;
 
             // https://github.com/PrestaShop/PrestaShop/commit/2a3269ad93b1985f2615d6604458061d4989f0ea#diff-e98d435095567c145b49744715fd575eaab7050328c211b33aa9a37158421ff4R2186
@@ -76,7 +77,9 @@ class StockRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by sa.id_stock_available.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -85,11 +88,15 @@ class StockRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('sa.id_stock_available > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -117,8 +124,9 @@ class StockRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with sa.id_stock_available > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -126,14 +134,18 @@ class StockRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('sa.id_stock_available > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/StoreRepository.php
+++ b/src/Repository/StoreRepository.php
@@ -67,6 +67,7 @@ class StoreRepository extends AbstractRepository implements RepositoryInterface
                 ->select('s.active')
                 ->select('s.date_add as created_at')
                 ->select('s.date_upd as updated_at')
+                ->orderBy('s.id_store ASC')
             ;
 
             // https://github.com/PrestaShop/PrestaShop/commit/7dda2be62d8bd606edc269fa051c36ea68f81682#diff-e98d435095567c145b49744715fd575eaab7050328c211b33aa9a37158421ff4R2004
@@ -91,7 +92,9 @@ class StoreRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by s.id_store.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -100,11 +103,15 @@ class StoreRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('s.id_store > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -132,8 +139,9 @@ class StoreRepository extends AbstractRepository implements RepositoryInterface
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with s.id_store > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -141,14 +149,18 @@ class StoreRepository extends AbstractRepository implements RepositoryInterface
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('s.id_store > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/SupplierRepository.php
+++ b/src/Repository/SupplierRepository.php
@@ -65,6 +65,7 @@ class SupplierRepository extends AbstractRepository implements RepositoryInterfa
                 ->select('sul.meta_title')
                 ->select('sul.meta_description')
                 ->select('sus.id_shop')
+                ->orderBy('su.id_supplier ASC')
             ;
 
             // REMOVED HERE: https://github.com/PrestaShop/PrestaShop/commit/f37a8f61017654bae160b528a1a2eaf49edbdac0
@@ -75,7 +76,9 @@ class SupplierRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by su.id_supplier.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -84,11 +87,15 @@ class SupplierRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('su.id_supplier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -116,8 +123,9 @@ class SupplierRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with su.id_supplier > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -125,14 +133,18 @@ class SupplierRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('su.id_supplier > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/SyncRepository.php
+++ b/src/Repository/SyncRepository.php
@@ -37,20 +37,20 @@ class SyncRepository extends AbstractRepository
 
     /**
      * @param string $type
+     * @param string|null $lastSeekKey
      * @param string $date
      * @param bool $fullSyncFinished
      * @param string $langIso
-     * @param string|null $lastSeekKey
      *
      * @return bool
      */
-    public function upsertTypeSync($type, $date, $fullSyncFinished, $langIso = null, $lastSeekKey = null)
+    public function upsertTypeSync($type, $lastSeekKey, $date, $fullSyncFinished, $langIso = null)
     {
         return $this->db->insert(
             self::TYPE_SYNC_TABLE_NAME,
             [
                 'type' => pSQL((string) $type),
-                'last_seek_key' => $lastSeekKey === null ? null : pSQL((string) $lastSeekKey),
+                'last_seek_key' => $lastSeekKey,
                 'id_shop' => parent::getShopContext()->id,
                 'lang_iso' => pSQL((string) $langIso),
                 'full_sync_finished' => (int) $fullSyncFinished,
@@ -85,7 +85,7 @@ class SyncRepository extends AbstractRepository
 
         $value = $this->db->getValue($this->query);
 
-        return $value === false || $value === null || $value === '' ? null : (string) $value;
+        return $value === false ? null : $value;
     }
 
     /**

--- a/src/Repository/SyncRepository.php
+++ b/src/Repository/SyncRepository.php
@@ -37,20 +37,20 @@ class SyncRepository extends AbstractRepository
 
     /**
      * @param string $type
-     * @param int $offset
      * @param string $date
      * @param bool $fullSyncFinished
      * @param string $langIso
+     * @param string|null $lastSeekKey
      *
      * @return bool
      */
-    public function upsertTypeSync($type, $offset, $date, $fullSyncFinished, $langIso = null)
+    public function upsertTypeSync($type, $date, $fullSyncFinished, $langIso = null, $lastSeekKey = null)
     {
         return $this->db->insert(
             self::TYPE_SYNC_TABLE_NAME,
             [
                 'type' => pSQL((string) $type),
-                'offset' => (int) $offset,
+                'last_seek_key' => $lastSeekKey === null ? null : pSQL((string) $lastSeekKey),
                 'id_shop' => parent::getShopContext()->id,
                 'lang_iso' => pSQL((string) $langIso),
                 'full_sync_finished' => (int) $fullSyncFinished,
@@ -60,6 +60,32 @@ class SyncRepository extends AbstractRepository
             true,
             \Db::ON_DUPLICATE_KEY
         );
+    }
+
+    /**
+     * Returns the last emitted seek key for the (type, lang, shop) cursor,
+     * or null when full sync has not started or no row was emitted yet.
+     *
+     * @param string $type
+     * @param string|null $langIso
+     *
+     * @return string|null
+     */
+    public function getLastSeekKey($type, $langIso = null)
+    {
+        $this->generateMinimalQuery(self::TYPE_SYNC_TABLE_NAME, 'ets');
+
+        $this->query
+            ->where('ets.type = "' . pSQL($type) . '"')
+            ->where('ets.lang_iso = "' . pSQL((string) $langIso) . '"')
+            ->where('ets.id_shop = ' . parent::getShopContext()->id)
+        ;
+
+        $this->query->select('ets.last_seek_key');
+
+        $value = $this->db->getValue($this->query);
+
+        return $value === false || $value === null || $value === '' ? null : (string) $value;
     }
 
     /**

--- a/src/Repository/SyncRepository.php
+++ b/src/Repository/SyncRepository.php
@@ -85,7 +85,7 @@ class SyncRepository extends AbstractRepository
 
         $value = $this->db->getValue($this->query);
 
-        return $value === false ? null : $value;
+        return $value === false || $value === '' ? null : $value;
     }
 
     /**

--- a/src/Repository/TaxonomyRepository.php
+++ b/src/Repository/TaxonomyRepository.php
@@ -52,12 +52,15 @@ class TaxonomyRepository extends AbstractRepository implements RepositoryInterfa
             $this->query
                 ->select('fbcm.id_category')
                 ->select('fbcm.google_category_id')
+                ->orderBy('fbcm.id_category ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by fbcm.id_category.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -66,11 +69,15 @@ class TaxonomyRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('fbcm.id_category > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -98,8 +105,9 @@ class TaxonomyRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with fbcm.id_category > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -107,14 +115,18 @@ class TaxonomyRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('fbcm.id_category > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/TranslationRepository.php
+++ b/src/Repository/TranslationRepository.php
@@ -54,12 +54,15 @@ class TranslationRepository extends AbstractRepository implements RepositoryInte
                 ->select('t.translation')
                 ->select('t.domain')
                 ->select('t.theme')
+                ->orderBy('t.id_translation ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by t.id_translation.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -68,11 +71,15 @@ class TranslationRepository extends AbstractRepository implements RepositoryInte
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('t.id_translation > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -100,8 +107,9 @@ class TranslationRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with t.id_translation > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -109,14 +117,18 @@ class TranslationRepository extends AbstractRepository implements RepositoryInte
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('t.id_translation > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/WishlistProductRepository.php
+++ b/src/Repository/WishlistProductRepository.php
@@ -54,12 +54,15 @@ class WishlistProductRepository extends AbstractRepository implements Repository
                 ->select('wp.id_product_attribute')
                 ->select('wp.quantity')
                 ->select('wp.priority')
+                ->orderBy('wp.id_wishlist ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by wp.id_wishlist.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -68,11 +71,15 @@ class WishlistProductRepository extends AbstractRepository implements Repository
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('wp.id_wishlist > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -100,8 +107,9 @@ class WishlistProductRepository extends AbstractRepository implements Repository
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with wp.id_wishlist > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -109,14 +117,18 @@ class WishlistProductRepository extends AbstractRepository implements Repository
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('wp.id_wishlist > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Repository/WishlistRepository.php
+++ b/src/Repository/WishlistRepository.php
@@ -60,12 +60,15 @@ class WishlistRepository extends AbstractRepository implements RepositoryInterfa
                 ->select('w.date_add AS created_at')
                 ->select('w.date_upd as updated_at')
                 ->select('w.default')
+                ->orderBy('w.id_wishlist ASC')
             ;
         }
     }
 
     /**
-     * @param int $offset
+     * Seek-based page: returns rows strictly after $lastSeekKey, ordered by w.id_wishlist.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
@@ -74,11 +77,15 @@ class WishlistRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function retrieveContentsForFull($offset, $limit, $langIso)
+    public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
 
-        $this->query->limit((int) $limit, (int) $offset);
+        if ($lastSeekKey !== null) {
+            $this->query->where('w.id_wishlist > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
     }
@@ -106,8 +113,9 @@ class WishlistRepository extends AbstractRepository implements RepositoryInterfa
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * Count rows with w.id_wishlist > cursor.
+     *
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
@@ -115,14 +123,18 @@ class WishlistRepository extends AbstractRepository implements RepositoryInterfa
      * @throws \PrestaShopException
      * @throws \PrestaShopDatabaseException
      */
-    public function countFullSyncContentLeft($offset, $limit, $langIso)
+    public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
         $this->generateFullQuery($langIso, false);
 
-        $this->query->select('(COUNT(*) - ' . (int) $offset . ') as count');
+        if ($lastSeekKey !== null) {
+            $this->query->where('w.id_wishlist > ' . (int) $lastSeekKey);
+        }
+
+        $this->query->select('COUNT(*) as count');
 
         $result = $this->runQuery(true);
 
-        return !empty($result[0]['count']) ? $result[0]['count'] : 0;
+        return !empty($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }
 }

--- a/src/Service/ApiShopContentService.php
+++ b/src/Service/ApiShopContentService.php
@@ -119,6 +119,7 @@ class ApiShopContentService
 
                 $this->syncRepository->upsertTypeSync(
                     $shopContent,
+                    null,
                     $dateNow,
                     false,
                     $langIso

--- a/src/Service/ApiShopContentService.php
+++ b/src/Service/ApiShopContentService.php
@@ -110,8 +110,6 @@ class ApiShopContentService
             // If no typesync exist, or if fullsync is requested by user
             if (!is_array($typeSync) || $fullSyncRequested) {
                 $isFullSync = true;
-                $fullSyncIsFinished = false;
-                $offset = 0;
 
                 if ($typeSync) {
                     /** @var IncrementalSyncRepository $incrementalSyncRepository */
@@ -121,21 +119,16 @@ class ApiShopContentService
 
                 $this->syncRepository->upsertTypeSync(
                     $shopContent,
-                    $offset,
                     $dateNow,
-                    $fullSyncIsFinished,
+                    false,
                     $langIso
                 );
             // Else if fullsync is not finished
             } elseif (!boolval($typeSync['full_sync_finished'])) {
                 $isFullSync = true;
-                $fullSyncIsFinished = false;
-                $offset = (int) $typeSync['offset'];
             // Else, we are in incremental sync
             } else {
                 $isFullSync = false;
-                $fullSyncIsFinished = $typeSync['full_sync_finished'];
-                $offset = (int) $typeSync['offset'];
             }
 
             if ($isFullSync) {
@@ -143,7 +136,6 @@ class ApiShopContentService
                     $shopContent,
                     $jobId,
                     $langIso,
-                    $offset,
                     $limit,
                     $this->startTime,
                     $dateNow

--- a/src/Service/ShopContent/BundlesService.php
+++ b/src/Service/ShopContent/BundlesService.php
@@ -44,29 +44,38 @@ class BundlesService extends ShopContentAbstractService implements ShopContentSe
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->bundleRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->bundleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_bundle']);
+
+            $this->castBundles($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_BUNDLES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castBundles($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_BUNDLES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class BundlesService extends ShopContentAbstractService implements ShopContentSe
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->bundleRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->bundleRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/BundlesService.php
+++ b/src/Service/ShopContent/BundlesService.php
@@ -52,16 +52,16 @@ class BundlesService extends ShopContentAbstractService implements ShopContentSe
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->bundleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->bundleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_bundle']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_bundle'];
 
-            $this->castBundles($rawRows);
+            $this->castBundles($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class BundlesService extends ShopContentAbstractService implements ShopContentSe
                     'collection' => Config::COLLECTION_BUNDLES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CarrierDetailsService.php
+++ b/src/Service/ShopContent/CarrierDetailsService.php
@@ -52,16 +52,16 @@ class CarrierDetailsService extends ShopContentAbstractService implements ShopCo
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->carrierDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->carrierDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_carrier']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_carrier'];
 
-            $this->castCarrierDetails($rawRows);
+            $this->castCarrierDetails($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CarrierDetailsService extends ShopContentAbstractService implements ShopCo
                     'collection' => Config::COLLECTION_CARRIER_DETAILS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CarrierDetailsService.php
+++ b/src/Service/ShopContent/CarrierDetailsService.php
@@ -52,10 +52,9 @@ class CarrierDetailsService extends ShopContentAbstractService implements ShopCo
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $page = $this->carrierDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
-        $result = $page['rows'];
+        $result = $this->carrierDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        $newSeekKey = $page['lastId'] !== null ? (string) $page['lastId'] : $lastSeekKey;
+        $newSeekKey = (string) ((int) $lastSeekKey + count($result));
         $rows = [];
 
         if (!empty($result)) {
@@ -104,6 +103,19 @@ class CarrierDetailsService extends ShopContentAbstractService implements ShopCo
     public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
         return $this->carrierDetailRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
+    }
+
+    /**
+     * Cursor is a row offset, not a content id — a numeric compare against
+     * id_carrier would be misleading. Always record: over-recording during
+     * full sync is safe (incremental sync will re-upload extra rows), while
+     * under-recording could drop a mutation to an already-uploaded carrier.
+     *
+     * {@inheritdoc}
+     */
+    public function isAtOrBehindSeekKey($id, $cursor)
+    {
+        return true;
     }
 
     /**

--- a/src/Service/ShopContent/CarrierDetailsService.php
+++ b/src/Service/ShopContent/CarrierDetailsService.php
@@ -58,8 +58,7 @@ class CarrierDetailsService extends ShopContentAbstractService implements ShopCo
         $rows = [];
 
         if (!empty($result)) {
-            $lastRow = end($result);
-            $newSeekKey = (string) (int) $lastRow['id_carrier'];
+            $newSeekKey = (string) max(array_map('intval', array_column($result, 'id_reference')));
 
             $this->castCarrierDetails($result);
 

--- a/src/Service/ShopContent/CarrierDetailsService.php
+++ b/src/Service/ShopContent/CarrierDetailsService.php
@@ -44,29 +44,38 @@ class CarrierDetailsService extends ShopContentAbstractService implements ShopCo
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->carrierDetailRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->carrierDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_carrier']);
+
+            $this->castCarrierDetails($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CARRIER_DETAILS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCarrierDetails($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CARRIER_DETAILS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CarrierDetailsService extends ShopContentAbstractService implements ShopCo
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->carrierDetailRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->carrierDetailRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CarrierDetailsService.php
+++ b/src/Service/ShopContent/CarrierDetailsService.php
@@ -52,14 +52,13 @@ class CarrierDetailsService extends ShopContentAbstractService implements ShopCo
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->carrierDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $page = $this->carrierDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $page['rows'];
 
-        $newSeekKey = $lastSeekKey;
+        $newSeekKey = $page['lastId'] !== null ? (string) $page['lastId'] : $lastSeekKey;
         $rows = [];
 
         if (!empty($result)) {
-            $newSeekKey = (string) max(array_map('intval', array_column($result, 'id_reference')));
-
             $this->castCarrierDetails($result);
 
             $rows = array_map(function ($item) {

--- a/src/Service/ShopContent/CarrierTaxesService.php
+++ b/src/Service/ShopContent/CarrierTaxesService.php
@@ -52,16 +52,16 @@ class CarrierTaxesService extends ShopContentAbstractService implements ShopCont
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->carrierTaxeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->carrierTaxeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_carrier']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_carrier'];
 
-            $this->castCarrierTaxes($rawRows);
+            $this->castCarrierTaxes($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CarrierTaxesService extends ShopContentAbstractService implements ShopCont
                     'collection' => Config::COLLECTION_CARRIER_TAXES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CarrierTaxesService.php
+++ b/src/Service/ShopContent/CarrierTaxesService.php
@@ -44,29 +44,38 @@ class CarrierTaxesService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->carrierTaxeRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->carrierTaxeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_carrier']);
+
+            $this->castCarrierTaxes($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CARRIER_TAXES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCarrierTaxes($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CARRIER_TAXES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CarrierTaxesService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->carrierTaxeRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->carrierTaxeRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CarriersService.php
+++ b/src/Service/ShopContent/CarriersService.php
@@ -52,16 +52,16 @@ class CarriersService extends ShopContentAbstractService implements ShopContentS
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->carrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->carrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_carrier']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_carrier'];
 
-            $this->castCarriers($rawRows);
+            $this->castCarriers($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CarriersService extends ShopContentAbstractService implements ShopContentS
                     'collection' => Config::COLLECTION_CARRIERS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CarriersService.php
+++ b/src/Service/ShopContent/CarriersService.php
@@ -44,29 +44,38 @@ class CarriersService extends ShopContentAbstractService implements ShopContentS
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->carrierRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->carrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_carrier']);
+
+            $this->castCarriers($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CARRIERS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCarriers($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CARRIERS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CarriersService extends ShopContentAbstractService implements ShopContentS
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->carrierRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->carrierRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CartProductsService.php
+++ b/src/Service/ShopContent/CartProductsService.php
@@ -52,15 +52,13 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->cartProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $page = $this->cartProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $page['rows'];
 
-        $newSeekKey = $lastSeekKey;
+        $newSeekKey = $page['lastId'] !== null ? (string) $page['lastId'] : $lastSeekKey;
         $rows = [];
 
         if (!empty($result)) {
-            $lastRow = end($result);
-            $newSeekKey = (string) (int) $lastRow['id_cart'];
-
             $this->castCartProducts($result);
 
             $rows = array_map(function ($item) {

--- a/src/Service/ShopContent/CartProductsService.php
+++ b/src/Service/ShopContent/CartProductsService.php
@@ -44,29 +44,38 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->cartProductRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->cartProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_cart']);
+
+            $this->castCartProducts($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CART_PRODUCTS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCartProducts($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CART_PRODUCTS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->cartProductRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->cartProductRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CartProductsService.php
+++ b/src/Service/ShopContent/CartProductsService.php
@@ -52,10 +52,9 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $page = $this->cartProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
-        $result = $page['rows'];
+        $result = $this->cartProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        $newSeekKey = $page['lastId'] !== null ? (string) $page['lastId'] : $lastSeekKey;
+        $newSeekKey = (string) ((int) $lastSeekKey + count($result));
         $rows = [];
 
         if (!empty($result)) {
@@ -104,6 +103,19 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
     public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
         return $this->cartProductRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
+    }
+
+    /**
+     * Cursor is a row offset, not a content id — a numeric compare against
+     * id_cart would be misleading. Always record: over-recording during full
+     * sync is safe (incremental sync will re-upload extra rows), while under-
+     * recording could drop a mutation to an already-uploaded cart.
+     *
+     * {@inheritdoc}
+     */
+    public function isAtOrBehindSeekKey($id, $cursor)
+    {
+        return true;
     }
 
     /**

--- a/src/Service/ShopContent/CartProductsService.php
+++ b/src/Service/ShopContent/CartProductsService.php
@@ -52,16 +52,16 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->cartProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->cartProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_cart']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_cart'];
 
-            $this->castCartProducts($rawRows);
+            $this->castCartProducts($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
                     'collection' => Config::COLLECTION_CART_PRODUCTS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CartRulesService.php
+++ b/src/Service/ShopContent/CartRulesService.php
@@ -44,29 +44,38 @@ class CartRulesService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->cartRuleRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->cartRuleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_cart_rule']);
+
+            $this->castCartRules($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CART_RULES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCartRules($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CART_RULES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CartRulesService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->cartRuleRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->cartRuleRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CartRulesService.php
+++ b/src/Service/ShopContent/CartRulesService.php
@@ -52,16 +52,16 @@ class CartRulesService extends ShopContentAbstractService implements ShopContent
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->cartRuleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->cartRuleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_cart_rule']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_cart_rule'];
 
-            $this->castCartRules($rawRows);
+            $this->castCartRules($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CartRulesService extends ShopContentAbstractService implements ShopContent
                     'collection' => Config::COLLECTION_CART_RULES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CartsService.php
+++ b/src/Service/ShopContent/CartsService.php
@@ -44,29 +44,38 @@ class CartsService extends ShopContentAbstractService implements ShopContentServ
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->cartRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->cartRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $this->castCarts($rawRows);
+
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_cart']);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CARTS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCarts($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CARTS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CartsService extends ShopContentAbstractService implements ShopContentServ
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->cartRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->cartRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CartsService.php
+++ b/src/Service/ShopContent/CartsService.php
@@ -52,16 +52,16 @@ class CartsService extends ShopContentAbstractService implements ShopContentServ
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->cartRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->cartRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $this->castCarts($rawRows);
+        if (!empty($result)) {
+            $this->castCarts($result);
 
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_cart']);
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_cart'];
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CartsService extends ShopContentAbstractService implements ShopContentServ
                     'collection' => Config::COLLECTION_CARTS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CategoriesService.php
+++ b/src/Service/ShopContent/CategoriesService.php
@@ -52,16 +52,16 @@ class CategoriesService extends ShopContentAbstractService implements ShopConten
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->categoryRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->categoryRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_category']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_category'];
 
-            $this->castCategories($rawRows);
+            $this->castCategories($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CategoriesService extends ShopContentAbstractService implements ShopConten
                     'collection' => Config::COLLECTION_CATEGORIES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CategoriesService.php
+++ b/src/Service/ShopContent/CategoriesService.php
@@ -44,29 +44,38 @@ class CategoriesService extends ShopContentAbstractService implements ShopConten
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->categoryRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->categoryRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_category']);
+
+            $this->castCategories($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CATEGORIES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCategories($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CATEGORIES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CategoriesService extends ShopContentAbstractService implements ShopConten
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->categoryRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->categoryRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CurrenciesService.php
+++ b/src/Service/ShopContent/CurrenciesService.php
@@ -52,16 +52,16 @@ class CurrenciesService extends ShopContentAbstractService implements ShopConten
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->currencyRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->currencyRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_currency']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_currency'];
 
-            $this->castCurrencies($rawRows);
+            $this->castCurrencies($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CurrenciesService extends ShopContentAbstractService implements ShopConten
                     'collection' => Config::COLLECTION_CURRENCIES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CurrenciesService.php
+++ b/src/Service/ShopContent/CurrenciesService.php
@@ -44,29 +44,38 @@ class CurrenciesService extends ShopContentAbstractService implements ShopConten
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->currencyRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->currencyRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_currency']);
+
+            $this->castCurrencies($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CURRENCIES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCurrencies($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CURRENCIES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CurrenciesService extends ShopContentAbstractService implements ShopConten
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->currencyRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->currencyRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CustomProductCarriersService.php
+++ b/src/Service/ShopContent/CustomProductCarriersService.php
@@ -44,27 +44,55 @@ class CustomProductCarriersService extends ShopContentAbstractService implements
     }
 
     /**
-     * @param int $offset
+     * Encode the composite outbox id_object "{id_product}-{id_carrier_reference}"
+     * into a lexicographically-comparable seek key matching the format
+     * produced inside getContentsForFull.
+     *
+     * @param string $idObject
+     *
+     * @return string
+     */
+    public function encodeOutboxIdAsSeekKey($idObject)
+    {
+        list($a, $b) = array_pad(explode('-', (string) $idObject, 2), 2, '0');
+
+        return $this->padInt((int) $a) . '-' . $this->padInt((int) $b);
+    }
+
+    /**
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->customProductCarrierRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->customProductCarrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $idCarrierReference = isset($lastRow['id_carrier_reference']) ? (int) $lastRow['id_carrier_reference'] : 0;
+            $newSeekKey = $this->padInt((int) $lastRow['id_product'])
+                . '-'
+                . $this->padInt($idCarrierReference);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CUSTOM_PRODUCT_CARRIERS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CUSTOM_PRODUCT_CARRIERS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -83,14 +111,13 @@ class CustomProductCarriersService extends ShopContentAbstractService implements
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->customProductCarrierRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->customProductCarrierRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 }

--- a/src/Service/ShopContent/CustomProductCarriersService.php
+++ b/src/Service/ShopContent/CustomProductCarriersService.php
@@ -44,22 +44,6 @@ class CustomProductCarriersService extends ShopContentAbstractService implements
     }
 
     /**
-     * Encode the composite outbox id_object "{id_product}-{id_carrier_reference}"
-     * into a lexicographically-comparable seek key matching the format
-     * produced inside getContentsForFull.
-     *
-     * @param string $idObject
-     *
-     * @return string
-     */
-    public function encodeOutboxIdAsSeekKey($idObject)
-    {
-        list($a, $b) = array_pad(explode('-', (string) $idObject, 2), 2, '0');
-
-        return $this->padInt((int) $a) . '-' . $this->padInt((int) $b);
-    }
-
-    /**
      * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
@@ -68,17 +52,15 @@ class CustomProductCarriersService extends ShopContentAbstractService implements
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->customProductCarrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->customProductCarrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
+        if (!empty($result)) {
+            $lastRow = end($result);
             $idCarrierReference = isset($lastRow['id_carrier_reference']) ? (int) $lastRow['id_carrier_reference'] : 0;
-            $newSeekKey = $this->padInt((int) $lastRow['id_product'])
-                . '-'
-                . $this->padInt($idCarrierReference);
+            $newSeekKey = ((int) $lastRow['id_product']) . '-' . ((int) $idCarrierReference);
 
             $rows = array_map(function ($item) {
                 return [
@@ -86,7 +68,7 @@ class CustomProductCarriersService extends ShopContentAbstractService implements
                     'collection' => Config::COLLECTION_CUSTOM_PRODUCT_CARRIERS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/CustomersService.php
+++ b/src/Service/ShopContent/CustomersService.php
@@ -44,29 +44,38 @@ class CustomersService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->customerRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->customerRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_customer']);
+
+            $this->castCustomers($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_CUSTOMERS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCustomers($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_CUSTOMERS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class CustomersService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->customerRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->customerRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/CustomersService.php
+++ b/src/Service/ShopContent/CustomersService.php
@@ -52,16 +52,16 @@ class CustomersService extends ShopContentAbstractService implements ShopContent
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->customerRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->customerRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_customer']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_customer'];
 
-            $this->castCustomers($rawRows);
+            $this->castCustomers($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class CustomersService extends ShopContentAbstractService implements ShopContent
                     'collection' => Config::COLLECTION_CUSTOMERS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/EmployeesService.php
+++ b/src/Service/ShopContent/EmployeesService.php
@@ -44,29 +44,38 @@ class EmployeesService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->employeeRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->employeeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_employee']);
+
+            $this->castEmployees($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_EMPLOYEES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castEmployees($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_EMPLOYEES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class EmployeesService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->employeeRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->employeeRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/EmployeesService.php
+++ b/src/Service/ShopContent/EmployeesService.php
@@ -52,16 +52,16 @@ class EmployeesService extends ShopContentAbstractService implements ShopContent
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->employeeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->employeeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_employee']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_employee'];
 
-            $this->castEmployees($rawRows);
+            $this->castEmployees($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class EmployeesService extends ShopContentAbstractService implements ShopContent
                     'collection' => Config::COLLECTION_EMPLOYEES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/ImageTypesService.php
+++ b/src/Service/ShopContent/ImageTypesService.php
@@ -44,29 +44,38 @@ class ImageTypesService extends ShopContentAbstractService implements ShopConten
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->imageTypeRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->imageTypeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_image_type']);
+
+            $this->castImageTypes($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_IMAGE_TYPES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castImageTypes($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_IMAGE_TYPES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class ImageTypesService extends ShopContentAbstractService implements ShopConten
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->imageTypeRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->imageTypeRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/ImageTypesService.php
+++ b/src/Service/ShopContent/ImageTypesService.php
@@ -52,16 +52,16 @@ class ImageTypesService extends ShopContentAbstractService implements ShopConten
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->imageTypeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->imageTypeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_image_type']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_image_type'];
 
-            $this->castImageTypes($rawRows);
+            $this->castImageTypes($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class ImageTypesService extends ShopContentAbstractService implements ShopConten
                     'collection' => Config::COLLECTION_IMAGE_TYPES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/ImagesService.php
+++ b/src/Service/ShopContent/ImagesService.php
@@ -44,29 +44,38 @@ class ImagesService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->imageRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->imageRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_image']);
+
+            $this->castImages($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_IMAGES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castImages($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_IMAGES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class ImagesService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->imageRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->imageRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/ImagesService.php
+++ b/src/Service/ShopContent/ImagesService.php
@@ -52,16 +52,16 @@ class ImagesService extends ShopContentAbstractService implements ShopContentSer
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->imageRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->imageRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_image']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_image'];
 
-            $this->castImages($rawRows);
+            $this->castImages($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class ImagesService extends ShopContentAbstractService implements ShopContentSer
                     'collection' => Config::COLLECTION_IMAGES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/InfoService.php
+++ b/src/Service/ShopContent/InfoService.php
@@ -156,5 +156,4 @@ class InfoService extends ShopContentAbstractService implements ShopContentServi
     {
         return 0;
     }
-
 }

--- a/src/Service/ShopContent/InfoService.php
+++ b/src/Service/ShopContent/InfoService.php
@@ -157,17 +157,4 @@ class InfoService extends ShopContentAbstractService implements ShopContentServi
         return 0;
     }
 
-    /**
-     * Info is a singleton payload, not a row in a paginated table. The
-     * outbox never references a numeric id_object for it, so collapse any
-     * encoding to the same sentinel value used as the seek key.
-     *
-     * @param string $idObject
-     *
-     * @return string
-     */
-    public function encodeOutboxIdAsSeekKey($idObject)
-    {
-        return 'DONE';
-    }
 }

--- a/src/Service/ShopContent/InfoService.php
+++ b/src/Service/ShopContent/InfoService.php
@@ -68,14 +68,22 @@ class InfoService extends ShopContentAbstractService implements ShopContentServi
     }
 
     /**
-     * @param int $offset
+     * Singleton payload: the shop "info" is a single synthetic row, not a
+     * paginated table. We emit it once on the first call, then report
+     * "done" for any subsequent call within the same full sync.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
+        if ($lastSeekKey !== null) {
+            return ['rows' => [], 'lastSeekKey' => 'DONE'];
+        }
+
         $langId = !empty($langIso) ? (int) \Language::getIdByIso($langIso) : null;
 
         /* This file is created on installation and never modified.
@@ -91,7 +99,7 @@ class InfoService extends ShopContentAbstractService implements ShopContentServi
             throw new \PrestaShopException('No link context');
         }
 
-        return [
+        $rows = [
             [
                 'action' => Config::INCREMENTAL_TYPE_UPSERT,
                 'collection' => 'shops',
@@ -121,6 +129,8 @@ class InfoService extends ShopContentAbstractService implements ShopContentServi
                 ],
             ],
         ];
+
+        return ['rows' => $rows, 'lastSeekKey' => 'DONE'];
     }
 
     /**
@@ -137,14 +147,27 @@ class InfoService extends ShopContentAbstractService implements ShopContentServi
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
         return 0;
+    }
+
+    /**
+     * Info is a singleton payload, not a row in a paginated table. The
+     * outbox never references a numeric id_object for it, so collapse any
+     * encoding to the same sentinel value used as the seek key.
+     *
+     * @param string $idObject
+     *
+     * @return string
+     */
+    public function encodeOutboxIdAsSeekKey($idObject)
+    {
+        return 'DONE';
     }
 }

--- a/src/Service/ShopContent/LanguagesService.php
+++ b/src/Service/ShopContent/LanguagesService.php
@@ -52,16 +52,16 @@ class LanguagesService extends ShopContentAbstractService implements ShopContent
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->languageRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->languageRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_lang']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_lang'];
 
-            $this->castLanguages($rawRows);
+            $this->castLanguages($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class LanguagesService extends ShopContentAbstractService implements ShopContent
                     'collection' => Config::COLLECTION_LANGUAGES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/LanguagesService.php
+++ b/src/Service/ShopContent/LanguagesService.php
@@ -44,29 +44,38 @@ class LanguagesService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->languageRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->languageRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_lang']);
+
+            $this->castLanguages($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_LANGUAGES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castLanguages($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_LANGUAGES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class LanguagesService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->languageRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->languageRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/ManufacturersService.php
+++ b/src/Service/ShopContent/ManufacturersService.php
@@ -52,16 +52,16 @@ class ManufacturersService extends ShopContentAbstractService implements ShopCon
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->manufacturerRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->manufacturerRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_manufacturer']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_manufacturer'];
 
-            $this->castManufacturers($rawRows);
+            $this->castManufacturers($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class ManufacturersService extends ShopContentAbstractService implements ShopCon
                     'collection' => Config::COLLECTION_MANUFACTURERS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/ManufacturersService.php
+++ b/src/Service/ShopContent/ManufacturersService.php
@@ -44,29 +44,38 @@ class ManufacturersService extends ShopContentAbstractService implements ShopCon
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->manufacturerRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->manufacturerRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_manufacturer']);
+
+            $this->castManufacturers($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_MANUFACTURERS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castManufacturers($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_MANUFACTURERS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class ManufacturersService extends ShopContentAbstractService implements ShopCon
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->manufacturerRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->manufacturerRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/ModulesService.php
+++ b/src/Service/ShopContent/ModulesService.php
@@ -59,16 +59,16 @@ class ModulesService extends ShopContentAbstractService implements ShopContentSe
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->moduleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->moduleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['module_id']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['module_id'];
 
-            $this->castModules($rawRows);
+            $this->castModules($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -76,7 +76,7 @@ class ModulesService extends ShopContentAbstractService implements ShopContentSe
                     'collection' => Config::COLLECTION_MODULES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/ModulesService.php
+++ b/src/Service/ShopContent/ModulesService.php
@@ -51,29 +51,38 @@ class ModulesService extends ShopContentAbstractService implements ShopContentSe
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->moduleRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->moduleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['module_id']);
+
+            $this->castModules($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_MODULES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castModules($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_MODULES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -98,15 +107,14 @@ class ModulesService extends ShopContentAbstractService implements ShopContentSe
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->moduleRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->moduleRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/OrderCarriersService.php
+++ b/src/Service/ShopContent/OrderCarriersService.php
@@ -52,16 +52,16 @@ class OrderCarriersService extends ShopContentAbstractService implements ShopCon
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->orderCarrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->orderCarrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_order_carrier']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_order_carrier'];
 
-            $this->castOrderCarriers($rawRows);
+            $this->castOrderCarriers($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class OrderCarriersService extends ShopContentAbstractService implements ShopCon
                     'collection' => Config::COLLECTION_ORDER_CARRIERS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/OrderCarriersService.php
+++ b/src/Service/ShopContent/OrderCarriersService.php
@@ -44,29 +44,38 @@ class OrderCarriersService extends ShopContentAbstractService implements ShopCon
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->orderCarrierRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->orderCarrierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_order_carrier']);
+
+            $this->castOrderCarriers($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_ORDER_CARRIERS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castOrderCarriers($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_ORDER_CARRIERS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class OrderCarriersService extends ShopContentAbstractService implements ShopCon
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->orderCarrierRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->orderCarrierRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/OrderCartRulesService.php
+++ b/src/Service/ShopContent/OrderCartRulesService.php
@@ -44,29 +44,38 @@ class OrderCartRulesService extends ShopContentAbstractService implements ShopCo
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->orderCartRuleRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->orderCartRuleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_order_cart_rule']);
+
+            $this->castOrderCartRules($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_ORDER_CART_RULES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castOrderCartRules($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_ORDER_CART_RULES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class OrderCartRulesService extends ShopContentAbstractService implements ShopCo
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->orderCartRuleRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->orderCartRuleRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/OrderCartRulesService.php
+++ b/src/Service/ShopContent/OrderCartRulesService.php
@@ -52,16 +52,16 @@ class OrderCartRulesService extends ShopContentAbstractService implements ShopCo
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->orderCartRuleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->orderCartRuleRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_order_cart_rule']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_order_cart_rule'];
 
-            $this->castOrderCartRules($rawRows);
+            $this->castOrderCartRules($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class OrderCartRulesService extends ShopContentAbstractService implements ShopCo
                     'collection' => Config::COLLECTION_ORDER_CART_RULES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/OrderDetailsService.php
+++ b/src/Service/ShopContent/OrderDetailsService.php
@@ -52,16 +52,16 @@ class OrderDetailsService extends ShopContentAbstractService implements ShopCont
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->orderDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->orderDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_order_detail']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_order_detail'];
 
-            $this->castOrderDetails($rawRows);
+            $this->castOrderDetails($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class OrderDetailsService extends ShopContentAbstractService implements ShopCont
                     'collection' => Config::COLLECTION_ORDER_DETAILS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/OrderDetailsService.php
+++ b/src/Service/ShopContent/OrderDetailsService.php
@@ -44,29 +44,38 @@ class OrderDetailsService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->orderDetailRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->orderDetailRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_order_detail']);
+
+            $this->castOrderDetails($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_ORDER_DETAILS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castOrderDetails($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_ORDER_DETAILS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class OrderDetailsService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->orderDetailRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->orderDetailRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/OrderStatusHistoryService.php
+++ b/src/Service/ShopContent/OrderStatusHistoryService.php
@@ -52,16 +52,16 @@ class OrderStatusHistoryService extends ShopContentAbstractService implements Sh
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->orderStatusHistoryRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->orderStatusHistoryRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_order_history']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_order_history'];
 
-            $this->castOrderStatusHistories($rawRows);
+            $this->castOrderStatusHistories($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class OrderStatusHistoryService extends ShopContentAbstractService implements Sh
                     'collection' => Config::COLLECTION_ORDER_STATUS_HISTORY,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/OrderStatusHistoryService.php
+++ b/src/Service/ShopContent/OrderStatusHistoryService.php
@@ -44,29 +44,38 @@ class OrderStatusHistoryService extends ShopContentAbstractService implements Sh
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->orderStatusHistoryRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->orderStatusHistoryRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_order_history']);
+
+            $this->castOrderStatusHistories($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_ORDER_STATUS_HISTORY,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castOrderStatusHistories($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_ORDER_STATUS_HISTORY,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class OrderStatusHistoryService extends ShopContentAbstractService implements Sh
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->orderStatusHistoryRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->orderStatusHistoryRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/OrdersService.php
+++ b/src/Service/ShopContent/OrdersService.php
@@ -57,29 +57,38 @@ class OrdersService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->orderRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->orderRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_order']);
+
+            $this->castOrders($rawRows, $langIso);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_ORDERS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castOrders($result, $langIso);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_ORDERS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -102,15 +111,14 @@ class OrdersService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->orderRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->orderRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/OrdersService.php
+++ b/src/Service/ShopContent/OrdersService.php
@@ -65,16 +65,16 @@ class OrdersService extends ShopContentAbstractService implements ShopContentSer
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->orderRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->orderRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_order']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_order'];
 
-            $this->castOrders($rawRows, $langIso);
+            $this->castOrders($result, $langIso);
 
             $rows = array_map(function ($item) {
                 return [
@@ -82,7 +82,7 @@ class OrdersService extends ShopContentAbstractService implements ShopContentSer
                     'collection' => Config::COLLECTION_ORDERS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/ProductSuppliersService.php
+++ b/src/Service/ShopContent/ProductSuppliersService.php
@@ -44,29 +44,38 @@ class ProductSuppliersService extends ShopContentAbstractService implements Shop
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->productSupplierRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->productSupplierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_product_supplier']);
+
+            $this->castProductsSuppliers($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_PRODUCT_SUPPLIERS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castProductsSuppliers($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_PRODUCT_SUPPLIERS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class ProductSuppliersService extends ShopContentAbstractService implements Shop
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->productSupplierRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->productSupplierRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/ProductSuppliersService.php
+++ b/src/Service/ShopContent/ProductSuppliersService.php
@@ -52,16 +52,16 @@ class ProductSuppliersService extends ShopContentAbstractService implements Shop
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->productSupplierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->productSupplierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_product_supplier']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_product_supplier'];
 
-            $this->castProductsSuppliers($rawRows);
+            $this->castProductsSuppliers($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class ProductSuppliersService extends ShopContentAbstractService implements Shop
                     'collection' => Config::COLLECTION_PRODUCT_SUPPLIERS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/ProductsService.php
+++ b/src/Service/ShopContent/ProductsService.php
@@ -81,30 +81,57 @@ class ProductsService extends ShopContentAbstractService implements ShopContentS
     }
 
     /**
-     * @param int $offset
+     * Encode the composite outbox id_object "{id_product}-{id_product_attribute}"
+     * into a lexicographically-comparable seek key matching the format
+     * produced inside getContentsForFull.
+     *
+     * @param string $idObject
+     *
+     * @return string
+     */
+    public function encodeOutboxIdAsSeekKey($idObject)
+    {
+        list($a, $b) = array_pad(explode('-', (string) $idObject, 2), 2, '0');
+
+        return $this->padInt((int) $a) . '-' . $this->padInt((int) $b);
+    }
+
+    /**
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->productRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->productRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_product'])
+                . '-'
+                . $this->padInt((int) $lastRow['id_attribute']);
+
+            $this->decorateProducts($rawRows, $langIso);
+            $this->castProducts($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_PRODUCTS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->decorateProducts($result, $langIso);
-        $this->castProducts($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_PRODUCTS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -128,15 +155,14 @@ class ProductsService extends ShopContentAbstractService implements ShopContentS
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->productRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->productRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/ProductsService.php
+++ b/src/Service/ShopContent/ProductsService.php
@@ -81,22 +81,6 @@ class ProductsService extends ShopContentAbstractService implements ShopContentS
     }
 
     /**
-     * Encode the composite outbox id_object "{id_product}-{id_product_attribute}"
-     * into a lexicographically-comparable seek key matching the format
-     * produced inside getContentsForFull.
-     *
-     * @param string $idObject
-     *
-     * @return string
-     */
-    public function encodeOutboxIdAsSeekKey($idObject)
-    {
-        list($a, $b) = array_pad(explode('-', (string) $idObject, 2), 2, '0');
-
-        return $this->padInt((int) $a) . '-' . $this->padInt((int) $b);
-    }
-
-    /**
      * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
@@ -105,19 +89,17 @@ class ProductsService extends ShopContentAbstractService implements ShopContentS
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->productRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->productRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_product'])
-                . '-'
-                . $this->padInt((int) $lastRow['id_attribute']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = ((int) $lastRow['id_product']) . '-' . ((int) $lastRow['id_attribute']);
 
-            $this->decorateProducts($rawRows, $langIso);
-            $this->castProducts($rawRows);
+            $this->decorateProducts($result, $langIso);
+            $this->castProducts($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -125,7 +107,7 @@ class ProductsService extends ShopContentAbstractService implements ShopContentS
                     'collection' => Config::COLLECTION_PRODUCTS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/ShopContentAbstractService.php
+++ b/src/Service/ShopContent/ShopContentAbstractService.php
@@ -35,6 +35,41 @@ if (!defined('_PS_VERSION_')) {
 abstract class ShopContentAbstractService
 {
     /**
+     * Default seek-key padding width. Subclasses whose primary key column
+     * is wider than INT UNSIGNED redeclare this constant (typically to
+     * ShopContentServiceInterface::SEEK_KEY_PAD_BIGINT).
+     */
+    const SEEK_KEY_PAD = ShopContentServiceInterface::SEEK_KEY_PAD_INT;
+
+    /**
+     * Default outbox id encoding: assume id_object is a plain integer.
+     * Subclasses with composite (e.g. ProductsService) or sentinel
+     * encodings (e.g. InfoService, ThemesService) override this.
+     *
+     * @param string $idObject
+     *
+     * @return string
+     */
+    public function encodeOutboxIdAsSeekKey($idObject)
+    {
+        return $this->padInt((int) $idObject);
+    }
+
+    /**
+     * Zero-pad an integer to SEEK_KEY_PAD digits so lexicographic string
+     * comparison matches numeric ordering. Uses static:: so subclasses
+     * that override SEEK_KEY_PAD pick up the wider width.
+     *
+     * @param int $value
+     *
+     * @return string
+     */
+    protected function padInt($value)
+    {
+        return str_pad((string) $value, static::SEEK_KEY_PAD, '0', STR_PAD_LEFT);
+    }
+
+    /**
      * @param string $collection
      * @param array<mixed> $upsertedContents
      * @param array<mixed> $deletedList

--- a/src/Service/ShopContent/ShopContentAbstractService.php
+++ b/src/Service/ShopContent/ShopContentAbstractService.php
@@ -35,38 +35,24 @@ if (!defined('_PS_VERSION_')) {
 abstract class ShopContentAbstractService
 {
     /**
-     * Default seek-key padding width. Subclasses whose primary key column
-     * is wider than INT UNSIGNED redeclare this constant (typically to
-     * ShopContentServiceInterface::SEEK_KEY_PAD_BIGINT).
-     */
-    const SEEK_KEY_PAD = ShopContentServiceInterface::SEEK_KEY_PAD_INT;
-
-    /**
-     * Default outbox id encoding: assume id_object is a plain integer.
-     * Subclasses with composite (e.g. ProductsService) or sentinel
-     * encodings (e.g. InfoService, ThemesService) override this.
+     * Compare two seek keys (plain "123" or composite "a-b") as int tuples.
      *
-     * @param string $idObject
+     * @param string $id
+     * @param string $cursor
      *
-     * @return string
+     * @return bool true when $id is at or behind $cursor (id <= cursor)
      */
-    public function encodeOutboxIdAsSeekKey($idObject)
+    public function isAtOrBehindSeekKey($id, $cursor)
     {
-        return $this->padInt((int) $idObject);
-    }
-
-    /**
-     * Zero-pad an integer to SEEK_KEY_PAD digits so lexicographic string
-     * comparison matches numeric ordering. Uses static:: so subclasses
-     * that override SEEK_KEY_PAD pick up the wider width.
-     *
-     * @param int $value
-     *
-     * @return string
-     */
-    protected function padInt($value)
-    {
-        return str_pad((string) $value, static::SEEK_KEY_PAD, '0', STR_PAD_LEFT);
+        $a = array_map('intval', explode('-', (string) $id));
+        $b = array_map('intval', explode('-', (string) $cursor));
+        $n = min(count($a), count($b));
+        for ($i = 0; $i < $n; $i++) {
+            if ($a[$i] !== $b[$i]) {
+                return $a[$i] < $b[$i];
+            }
+        }
+        return count($a) <= count($b);
     }
 
     /**

--- a/src/Service/ShopContent/ShopContentAbstractService.php
+++ b/src/Service/ShopContent/ShopContentAbstractService.php
@@ -47,11 +47,12 @@ abstract class ShopContentAbstractService
         $a = array_map('intval', explode('-', (string) $id));
         $b = array_map('intval', explode('-', (string) $cursor));
         $n = min(count($a), count($b));
-        for ($i = 0; $i < $n; $i++) {
+        for ($i = 0; $i < $n; ++$i) {
             if ($a[$i] !== $b[$i]) {
                 return $a[$i] < $b[$i];
             }
         }
+
         return count($a) <= count($b);
     }
 

--- a/src/Service/ShopContent/ShopContentServiceInterface.php
+++ b/src/Service/ShopContent/ShopContentServiceInterface.php
@@ -33,18 +33,6 @@ if (!defined('_PS_VERSION_')) {
 interface ShopContentServiceInterface
 {
     /**
-     * Zero-pad width for INT UNSIGNED primary keys (max 4 294 967 295,
-     * 10 digits + 1 headroom).
-     */
-    const SEEK_KEY_PAD_INT = 11;
-
-    /**
-     * Zero-pad width for BIGINT UNSIGNED primary keys (max
-     * 18 446 744 073 709 551 615, 20 digits).
-     */
-    const SEEK_KEY_PAD_BIGINT = 20;
-
-    /**
      * Fetch one page of full-sync content strictly after $lastSeekKey.
      *
      * @param string|null $lastSeekKey cursor from the previous page, or null on first call
@@ -66,22 +54,12 @@ interface ShopContentServiceInterface
     public function getContentsForIncremental($limit, $upsertedContents, $deletedContents, $langIso);
 
     /**
-     * @param string|null $lastSeekKey
-     * @param string $langIso
+     * Compare two seek keys (plain "123" or composite "a-b") as int tuples.
      *
-     * @return int
+     * @param string $id
+     * @param string $cursor
+     *
+     * @return bool
      */
-    public function getFullSyncContentLeft($lastSeekKey, $langIso);
-
-    /**
-     * Encode an outbox id_object string (as written by
-     * SynchronizationService::insertContentIntoIncremental) into the same
-     * lexicographically comparable form used for seek keys, so the outbox
-     * gate can compare them with strcmp.
-     *
-     * @param string $idObject
-     *
-     * @return string
-     */
-    public function encodeOutboxIdAsSeekKey($idObject);
+    public function isAtOrBehindSeekKey($id, $cursor);
 }

--- a/src/Service/ShopContent/ShopContentServiceInterface.php
+++ b/src/Service/ShopContent/ShopContentServiceInterface.php
@@ -33,13 +33,27 @@ if (!defined('_PS_VERSION_')) {
 interface ShopContentServiceInterface
 {
     /**
-     * @param int $offset
+     * Zero-pad width for INT UNSIGNED primary keys (max 4 294 967 295,
+     * 10 digits + 1 headroom).
+     */
+    const SEEK_KEY_PAD_INT = 11;
+
+    /**
+     * Zero-pad width for BIGINT UNSIGNED primary keys (max
+     * 18 446 744 073 709 551 615, 20 digits).
+     */
+    const SEEK_KEY_PAD_BIGINT = 20;
+
+    /**
+     * Fetch one page of full-sync content strictly after $lastSeekKey.
+     *
+     * @param string|null $lastSeekKey cursor from the previous page, or null on first call
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso);
+    public function getContentsForFull($lastSeekKey, $limit, $langIso);
 
     /**
      * @param int $limit
@@ -52,11 +66,22 @@ interface ShopContentServiceInterface
     public function getContentsForIncremental($limit, $upsertedContents, $deletedContents, $langIso);
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso);
+    public function getFullSyncContentLeft($lastSeekKey, $langIso);
+
+    /**
+     * Encode an outbox id_object string (as written by
+     * SynchronizationService::insertContentIntoIncremental) into the same
+     * lexicographically comparable form used for seek keys, so the outbox
+     * gate can compare them with strcmp.
+     *
+     * @param string $idObject
+     *
+     * @return string
+     */
+    public function encodeOutboxIdAsSeekKey($idObject);
 }

--- a/src/Service/ShopContent/ShopContentServiceInterface.php
+++ b/src/Service/ShopContent/ShopContentServiceInterface.php
@@ -54,6 +54,14 @@ interface ShopContentServiceInterface
     public function getContentsForIncremental($limit, $upsertedContents, $deletedContents, $langIso);
 
     /**
+     * @param string|null $lastSeekKey
+     * @param string $langIso
+     *
+     * @return int
+     */
+    public function getFullSyncContentLeft($lastSeekKey, $langIso);
+
+    /**
      * Compare two seek keys (plain "123" or composite "a-b") as int tuples.
      *
      * @param string $id

--- a/src/Service/ShopContent/SpecificPricesService.php
+++ b/src/Service/ShopContent/SpecificPricesService.php
@@ -51,29 +51,38 @@ class SpecificPricesService extends ShopContentAbstractService implements ShopCo
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->specificPriceRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->specificPriceRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_specific_price']);
+
+            $this->castCustomPrices($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_SPECIFIC_PRICES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castCustomPrices($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_SPECIFIC_PRICES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -96,15 +105,14 @@ class SpecificPricesService extends ShopContentAbstractService implements ShopCo
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->specificPriceRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->specificPriceRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/SpecificPricesService.php
+++ b/src/Service/ShopContent/SpecificPricesService.php
@@ -59,16 +59,16 @@ class SpecificPricesService extends ShopContentAbstractService implements ShopCo
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->specificPriceRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->specificPriceRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_specific_price']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_specific_price'];
 
-            $this->castCustomPrices($rawRows);
+            $this->castCustomPrices($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -76,7 +76,7 @@ class SpecificPricesService extends ShopContentAbstractService implements ShopCo
                     'collection' => Config::COLLECTION_SPECIFIC_PRICES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/StockMovementsService.php
+++ b/src/Service/ShopContent/StockMovementsService.php
@@ -52,16 +52,16 @@ class StockMovementsService extends ShopContentAbstractService implements ShopCo
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->stockMovementRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->stockMovementRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_stock_mvt']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_stock_mvt'];
 
-            $this->castStockMovements($rawRows);
+            $this->castStockMovements($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class StockMovementsService extends ShopContentAbstractService implements ShopCo
                     'collection' => Config::COLLECTION_STOCK_MOVEMENTS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/StockMovementsService.php
+++ b/src/Service/ShopContent/StockMovementsService.php
@@ -44,29 +44,38 @@ class StockMovementsService extends ShopContentAbstractService implements ShopCo
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->stockMovementRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->stockMovementRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_stock_mvt']);
+
+            $this->castStockMovements($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_STOCK_MOVEMENTS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castStockMovements($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_STOCK_MOVEMENTS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class StockMovementsService extends ShopContentAbstractService implements ShopCo
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->stockMovementRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->stockMovementRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/StocksService.php
+++ b/src/Service/ShopContent/StocksService.php
@@ -44,29 +44,38 @@ class StocksService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->stockRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->stockRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_stock_available']);
+
+            $this->castStocks($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_STOCKS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castStocks($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_STOCKS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class StocksService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->stockRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->stockRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/StocksService.php
+++ b/src/Service/ShopContent/StocksService.php
@@ -52,16 +52,16 @@ class StocksService extends ShopContentAbstractService implements ShopContentSer
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->stockRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->stockRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_stock_available']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_stock_available'];
 
-            $this->castStocks($rawRows);
+            $this->castStocks($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class StocksService extends ShopContentAbstractService implements ShopContentSer
                     'collection' => Config::COLLECTION_STOCKS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/StoresService.php
+++ b/src/Service/ShopContent/StoresService.php
@@ -44,29 +44,38 @@ class StoresService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->storeRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->storeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_store']);
+
+            $this->castStores($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_STORES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castStores($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_STORES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class StoresService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->storeRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->storeRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/StoresService.php
+++ b/src/Service/ShopContent/StoresService.php
@@ -52,16 +52,16 @@ class StoresService extends ShopContentAbstractService implements ShopContentSer
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->storeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->storeRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_store']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_store'];
 
-            $this->castStores($rawRows);
+            $this->castStores($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class StoresService extends ShopContentAbstractService implements ShopContentSer
                     'collection' => Config::COLLECTION_STORES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/SuppliersService.php
+++ b/src/Service/ShopContent/SuppliersService.php
@@ -44,29 +44,38 @@ class SuppliersService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->supplierRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->supplierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_supplier']);
+
+            $this->castSuppliers($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_SUPPLIERS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castSuppliers($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_SUPPLIERS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class SuppliersService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->supplierRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->supplierRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/SuppliersService.php
+++ b/src/Service/ShopContent/SuppliersService.php
@@ -52,16 +52,16 @@ class SuppliersService extends ShopContentAbstractService implements ShopContent
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->supplierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->supplierRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_supplier']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_supplier'];
 
-            $this->castSuppliers($rawRows);
+            $this->castSuppliers($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class SuppliersService extends ShopContentAbstractService implements ShopContent
                     'collection' => Config::COLLECTION_SUPPLIERS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/TaxonomiesService.php
+++ b/src/Service/ShopContent/TaxonomiesService.php
@@ -44,29 +44,38 @@ class TaxonomiesService extends ShopContentAbstractService implements ShopConten
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->taxonomyRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->taxonomyRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_category']);
+
+            $this->castTaxonomies($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_TAXONOMIES,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castTaxonomies($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_TAXONOMIES,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class TaxonomiesService extends ShopContentAbstractService implements ShopConten
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->taxonomyRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->taxonomyRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/TaxonomiesService.php
+++ b/src/Service/ShopContent/TaxonomiesService.php
@@ -52,16 +52,16 @@ class TaxonomiesService extends ShopContentAbstractService implements ShopConten
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->taxonomyRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->taxonomyRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_category']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_category'];
 
-            $this->castTaxonomies($rawRows);
+            $this->castTaxonomies($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class TaxonomiesService extends ShopContentAbstractService implements ShopConten
                     'collection' => Config::COLLECTION_TAXONOMIES,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/ThemesService.php
+++ b/src/Service/ShopContent/ThemesService.php
@@ -44,29 +44,39 @@ class ThemesService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
+     * Singleton payload: enumerate every installed theme once. Themes are
+     * a discovery-time list and not a paginated SQL table, so emit them
+     * on the first call and report "done" for any subsequent call.
+     *
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
+        if ($lastSeekKey !== null) {
+            return ['rows' => [], 'lastSeekKey' => 'DONE'];
+        }
+
         $result = $this->getAllThemes();
 
         if (empty($result)) {
-            return [];
+            return ['rows' => [], 'lastSeekKey' => 'DONE'];
         }
 
         $themes = $this->formatThemes($result);
 
-        return array_map(function ($item) {
+        $rows = array_map(function ($item) {
             return [
                 'action' => Config::INCREMENTAL_TYPE_UPSERT,
                 'collection' => Config::COLLECTION_THEMES,
                 'properties' => $item,
             ];
         }, $themes);
+
+        return ['rows' => $rows, 'lastSeekKey' => 'DONE'];
     }
 
     /**
@@ -83,15 +93,27 @@ class ThemesService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
         return 0;
+    }
+
+    /**
+     * Themes are a singleton payload, not a row in a paginated table.
+     * Collapse any outbox id_object to the same sentinel used as seek key.
+     *
+     * @param string $idObject
+     *
+     * @return string
+     */
+    public function encodeOutboxIdAsSeekKey($idObject)
+    {
+        return 'DONE';
     }
 
     /**

--- a/src/Service/ShopContent/ThemesService.php
+++ b/src/Service/ShopContent/ThemesService.php
@@ -104,19 +104,6 @@ class ThemesService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
-     * Themes are a singleton payload, not a row in a paginated table.
-     * Collapse any outbox id_object to the same sentinel used as seek key.
-     *
-     * @param string $idObject
-     *
-     * @return string
-     */
-    public function encodeOutboxIdAsSeekKey($idObject)
-    {
-        return 'DONE';
-    }
-
-    /**
      * Get all Themes
      *
      * @return mixed

--- a/src/Service/ShopContent/TranslationsService.php
+++ b/src/Service/ShopContent/TranslationsService.php
@@ -44,29 +44,38 @@ class TranslationsService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->translationRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->translationRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_translation']);
+
+            $this->castTranslations($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_TRANSLATIONS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castTranslations($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_TRANSLATIONS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class TranslationsService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->translationRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->translationRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/TranslationsService.php
+++ b/src/Service/ShopContent/TranslationsService.php
@@ -52,16 +52,16 @@ class TranslationsService extends ShopContentAbstractService implements ShopCont
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->translationRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->translationRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_translation']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_translation'];
 
-            $this->castTranslations($rawRows);
+            $this->castTranslations($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class TranslationsService extends ShopContentAbstractService implements ShopCont
                     'collection' => Config::COLLECTION_TRANSLATIONS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/WishlistProductsService.php
+++ b/src/Service/ShopContent/WishlistProductsService.php
@@ -52,16 +52,16 @@ class WishlistProductsService extends ShopContentAbstractService implements Shop
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->wishlistProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->wishlistProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_wishlist']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_wishlist'];
 
-            $this->castWishlistProducts($rawRows);
+            $this->castWishlistProducts($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class WishlistProductsService extends ShopContentAbstractService implements Shop
                     'collection' => Config::COLLECTION_WISHLIST_PRODUCTS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/ShopContent/WishlistProductsService.php
+++ b/src/Service/ShopContent/WishlistProductsService.php
@@ -44,29 +44,38 @@ class WishlistProductsService extends ShopContentAbstractService implements Shop
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->wishlistProductRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->wishlistProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_wishlist']);
+
+            $this->castWishlistProducts($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_WISHLIST_PRODUCTS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castWishlistProducts($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_WISHLIST_PRODUCTS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class WishlistProductsService extends ShopContentAbstractService implements Shop
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->wishlistProductRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->wishlistProductRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/WishlistsService.php
+++ b/src/Service/ShopContent/WishlistsService.php
@@ -44,29 +44,38 @@ class WishlistsService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
+     * @param string|null $lastSeekKey
      * @param int $limit
      * @param string $langIso
      *
-     * @return array<mixed>
+     * @return array{rows: array<mixed>, lastSeekKey: ?string}
      */
-    public function getContentsForFull($offset, $limit, $langIso)
+    public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $result = $this->wishlistRepository->retrieveContentsForFull($offset, $limit, $langIso);
+        $rawRows = $this->wishlistRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        if (empty($result)) {
-            return [];
+        $newSeekKey = $lastSeekKey;
+        $rows = [];
+
+        if (!empty($rawRows)) {
+            $lastRow = end($rawRows);
+            $newSeekKey = $this->padInt((int) $lastRow['id_wishlist']);
+
+            $this->castWishlists($rawRows);
+
+            $rows = array_map(function ($item) {
+                return [
+                    'action' => Config::INCREMENTAL_TYPE_UPSERT,
+                    'collection' => Config::COLLECTION_WISHLISTS,
+                    'properties' => $item,
+                ];
+            }, $rawRows);
         }
 
-        $this->castWishlists($result);
-
-        return array_map(function ($item) {
-            return [
-                'action' => Config::INCREMENTAL_TYPE_UPSERT,
-                'collection' => Config::COLLECTION_WISHLISTS,
-                'properties' => $item,
-            ];
-        }, $result);
+        return [
+            'rows' => $rows,
+            'lastSeekKey' => $newSeekKey,
+        ];
     }
 
     /**
@@ -89,15 +98,14 @@ class WishlistsService extends ShopContentAbstractService implements ShopContent
     }
 
     /**
-     * @param int $offset
-     * @param int $limit
+     * @param string|null $lastSeekKey
      * @param string $langIso
      *
      * @return int
      */
-    public function getFullSyncContentLeft($offset, $limit, $langIso)
+    public function getFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        return $this->wishlistRepository->countFullSyncContentLeft($offset, $limit, $langIso);
+        return $this->wishlistRepository->countFullSyncContentLeft($lastSeekKey, $langIso);
     }
 
     /**

--- a/src/Service/ShopContent/WishlistsService.php
+++ b/src/Service/ShopContent/WishlistsService.php
@@ -52,16 +52,16 @@ class WishlistsService extends ShopContentAbstractService implements ShopContent
      */
     public function getContentsForFull($lastSeekKey, $limit, $langIso)
     {
-        $rawRows = $this->wishlistRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
+        $result = $this->wishlistRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
         $newSeekKey = $lastSeekKey;
         $rows = [];
 
-        if (!empty($rawRows)) {
-            $lastRow = end($rawRows);
-            $newSeekKey = $this->padInt((int) $lastRow['id_wishlist']);
+        if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = (string) (int) $lastRow['id_wishlist'];
 
-            $this->castWishlists($rawRows);
+            $this->castWishlists($result);
 
             $rows = array_map(function ($item) {
                 return [
@@ -69,7 +69,7 @@ class WishlistsService extends ShopContentAbstractService implements ShopContent
                     'collection' => Config::COLLECTION_WISHLISTS,
                     'properties' => $item,
                 ];
-            }, $rawRows);
+            }, $result);
         }
 
         return [

--- a/src/Service/SynchronizationService.php
+++ b/src/Service/SynchronizationService.php
@@ -143,7 +143,7 @@ class SynchronizationService
 
         $fullSyncFinished = $remainingObjects <= 0;
 
-        $this->syncRepository->upsertTypeSync($shopContent, $dateNow, $fullSyncFinished, $langIso, $fullSyncFinished ? null : $newSeekKey);
+        $this->syncRepository->upsertTypeSync($shopContent, $fullSyncFinished ? null : $newSeekKey, $dateNow, $fullSyncFinished, $langIso);
 
         return $this->returnSyncResponse($data, $response, $fullSyncFinished ? 0 : $remainingObjects);
     }
@@ -267,6 +267,7 @@ class SynchronizationService
                     if ($hasDeleted) {
                         $this->syncRepository->upsertTypeSync(
                             $contentType,
+                            null,
                             $createdAt,
                             false,
                             $this->languagesService->getDefaultLanguageIsoCode()
@@ -414,7 +415,7 @@ class SynchronizationService
             return false;
         }
 
-        return strcmp($service->encodeOutboxIdAsSeekKey($contentId), $lastSeekKey) <= 0;
+        return $service->isAtOrBehindSeekKey($contentId, $lastSeekKey);
     }
 
     /**

--- a/src/Service/SynchronizationService.php
+++ b/src/Service/SynchronizationService.php
@@ -145,7 +145,10 @@ class SynchronizationService
 
         $this->syncRepository->upsertTypeSync($shopContent, $fullSyncFinished ? null : $newSeekKey, $dateNow, $fullSyncFinished, $langIso);
 
-        return $this->returnSyncResponse($data, $response, $fullSyncFinished ? 0 : $remainingObjects);
+        $reportedRemaining = $fullSyncFinished ? 0 : $remainingObjects;
+        $reportedRemaining += $this->incrementalSyncRepository->getRemainingIncrementalObjects($shopContent, $langIso);
+
+        return $this->returnSyncResponse($data, $response, $reportedRemaining);
     }
 
     /**

--- a/src/Service/SynchronizationService.php
+++ b/src/Service/SynchronizationService.php
@@ -279,64 +279,37 @@ class SynchronizationService
             }
         }
 
+        $isoCodes = $hasMultiLang
+            ? $this->languagesService->getLanguagesIsoCodes()
+            : [$this->languagesService->getDefaultLanguageIsoCode()];
+
         $contentToInsert = [];
 
-        if ($hasMultiLang) {
-            $allIsoCodes = $this->languagesService->getLanguagesIsoCodes();
-
-            foreach ($allIsoCodes as $langIso) {
-                foreach ($contentTypesWithIds as $contentType => $contentIds) {
-                    if (!is_array($contentIds)) {
-                        $contentIds = [$contentIds];
-                    }
-
-                    $finalContent = array_map(function ($contentId) use ($contentType, $shopId, $langIso, $actionType, $createdAt) {
-                        // transform id_product to unique_product_id
-                        if ($contentType == Config::COLLECTION_PRODUCTS) {
-                            $contentId = is_int($contentId) ? $contentId . '-0' : $contentId;
-                        }
-
-                        return [
-                            'type' => $contentType,
-                            'id_object' => $contentId,
-                            'id_shop' => $shopId,
-                            'lang_iso' => $langIso,
-                            'action' => $actionType,
-                            'created_at' => $createdAt,
-                        ];
-                    }, $contentIds);
-
-                    $finalContent = array_filter($finalContent, function ($item) use ($contentType, $langIso) {
-                        return $this->shouldRecordIntoOutbox($contentType, $langIso, (string) $item['id_object']);
-                    });
-
-                    $contentToInsert = array_merge($contentToInsert, $finalContent);
-                }
-            }
-        } else {
-            $defaultIsoCode = $this->languagesService->getDefaultLanguageIsoCode();
-
+        foreach ($isoCodes as $langIso) {
             foreach ($contentTypesWithIds as $contentType => $contentIds) {
                 if (!is_array($contentIds)) {
                     $contentIds = [$contentIds];
                 }
 
-                $finalContent = array_map(function ($contentId) use ($contentType, $shopId, $defaultIsoCode, $actionType, $createdAt) {
-                    return [
+                foreach ($contentIds as $contentId) {
+                    // transform id_product to unique_product_id (multi-lang path only, pre-existing behavior)
+                    if ($hasMultiLang && $contentType == Config::COLLECTION_PRODUCTS && is_int($contentId)) {
+                        $contentId = $contentId . '-0';
+                    }
+
+                    if (!$this->shouldRecordIntoOutbox($contentType, $langIso, (string) $contentId)) {
+                        continue;
+                    }
+
+                    $contentToInsert[] = [
                         'type' => $contentType,
                         'id_object' => $contentId,
                         'id_shop' => $shopId,
-                        'lang_iso' => $defaultIsoCode,
+                        'lang_iso' => $langIso,
                         'action' => $actionType,
                         'created_at' => $createdAt,
                     ];
-                }, $contentIds);
-
-                $finalContent = array_filter($finalContent, function ($item) use ($contentType, $defaultIsoCode) {
-                    return $this->shouldRecordIntoOutbox($contentType, $defaultIsoCode, (string) $item['id_object']);
-                });
-
-                $contentToInsert = array_merge($contentToInsert, $finalContent);
+                }
             }
         }
 

--- a/src/Service/SynchronizationService.php
+++ b/src/Service/SynchronizationService.php
@@ -286,61 +286,57 @@ class SynchronizationService
 
             foreach ($allIsoCodes as $langIso) {
                 foreach ($contentTypesWithIds as $contentType => $contentIds) {
-                    if ($this->isFullSyncDone($contentType, $langIso) || $this->syncRepository->getLastSeekKey($contentType, $langIso) !== null) {
-                        if (!is_array($contentIds)) {
-                            $contentIds = [$contentIds];
+                    if (!is_array($contentIds)) {
+                        $contentIds = [$contentIds];
+                    }
+
+                    $finalContent = array_map(function ($contentId) use ($contentType, $shopId, $langIso, $actionType, $createdAt) {
+                        // transform id_product to unique_product_id
+                        if ($contentType == Config::COLLECTION_PRODUCTS) {
+                            $contentId = is_int($contentId) ? $contentId . '-0' : $contentId;
                         }
 
-                        $finalContent = array_map(function ($contentId) use ($contentType, $shopId, $langIso, $actionType, $createdAt) {
-                            // transform id_product to unique_product_id
-                            if ($contentType == Config::COLLECTION_PRODUCTS) {
-                                $contentId = is_int($contentId) ? $contentId . '-0' : $contentId;
-                            }
+                        return [
+                            'type' => $contentType,
+                            'id_object' => $contentId,
+                            'id_shop' => $shopId,
+                            'lang_iso' => $langIso,
+                            'action' => $actionType,
+                            'created_at' => $createdAt,
+                        ];
+                    }, $contentIds);
 
-                            return [
-                                'type' => $contentType,
-                                'id_object' => $contentId,
-                                'id_shop' => $shopId,
-                                'lang_iso' => $langIso,
-                                'action' => $actionType,
-                                'created_at' => $createdAt,
-                            ];
-                        }, $contentIds);
+                    $finalContent = array_filter($finalContent, function ($item) use ($contentType, $langIso) {
+                        return $this->shouldRecordIntoOutbox($contentType, $langIso, (string) $item['id_object']);
+                    });
 
-                        $finalContent = array_filter($finalContent, function ($item) use ($contentType, $langIso) {
-                            return $this->shouldRecordIntoOutbox($contentType, $langIso, (string) $item['id_object']);
-                        });
-
-                        $contentToInsert = array_merge($contentToInsert, $finalContent);
-                    }
+                    $contentToInsert = array_merge($contentToInsert, $finalContent);
                 }
             }
         } else {
             $defaultIsoCode = $this->languagesService->getDefaultLanguageIsoCode();
 
             foreach ($contentTypesWithIds as $contentType => $contentIds) {
-                if ($this->isFullSyncDone($contentType, $defaultIsoCode) || $this->syncRepository->getLastSeekKey($contentType, $defaultIsoCode) !== null) {
-                    if (!is_array($contentIds)) {
-                        $contentIds = [$contentIds];
-                    }
-
-                    $finalContent = array_map(function ($contentId) use ($contentType, $shopId, $defaultIsoCode, $actionType, $createdAt) {
-                        return [
-                            'type' => $contentType,
-                            'id_object' => $contentId,
-                            'id_shop' => $shopId,
-                            'lang_iso' => $defaultIsoCode,
-                            'action' => $actionType,
-                            'created_at' => $createdAt,
-                        ];
-                    }, $contentIds);
-
-                    $finalContent = array_filter($finalContent, function ($item) use ($contentType, $defaultIsoCode) {
-                        return $this->shouldRecordIntoOutbox($contentType, $defaultIsoCode, (string) $item['id_object']);
-                    });
-
-                    $contentToInsert = array_merge($contentToInsert, $finalContent);
+                if (!is_array($contentIds)) {
+                    $contentIds = [$contentIds];
                 }
+
+                $finalContent = array_map(function ($contentId) use ($contentType, $shopId, $defaultIsoCode, $actionType, $createdAt) {
+                    return [
+                        'type' => $contentType,
+                        'id_object' => $contentId,
+                        'id_shop' => $shopId,
+                        'lang_iso' => $defaultIsoCode,
+                        'action' => $actionType,
+                        'created_at' => $createdAt,
+                    ];
+                }, $contentIds);
+
+                $finalContent = array_filter($finalContent, function ($item) use ($contentType, $defaultIsoCode) {
+                    return $this->shouldRecordIntoOutbox($contentType, $defaultIsoCode, (string) $item['id_object']);
+                });
+
+                $contentToInsert = array_merge($contentToInsert, $finalContent);
             }
         }
 

--- a/src/Service/SynchronizationService.php
+++ b/src/Service/SynchronizationService.php
@@ -126,8 +126,8 @@ class SynchronizationService
         $lastSeekKey = $this->syncRepository->getLastSeekKey($shopContent, $langIso);
 
         $page = $shopContentApiService->getContentsForFull($lastSeekKey, $limit, $langIso);
-        $data = isset($page['rows']) ? $page['rows'] : [];
-        $newSeekKey = isset($page['lastSeekKey']) ? $page['lastSeekKey'] : $lastSeekKey;
+        $data = $page['rows'];
+        $newSeekKey = $page['lastSeekKey'] !== null ? $page['lastSeekKey'] : $lastSeekKey;
         $remainingObjects = (int) $shopContentApiService->getFullSyncContentLeft($newSeekKey, $langIso);
 
         CommonService::convertDateFormat($data);

--- a/src/Service/SynchronizationService.php
+++ b/src/Service/SynchronizationService.php
@@ -92,7 +92,6 @@ class SynchronizationService
      * @param string $shopContent
      * @param string $jobId
      * @param string $langIso
-     * @param int $offset
      * @param int $limit
      * @param int $startTime
      * @param string $dateNow
@@ -105,7 +104,6 @@ class SynchronizationService
         string $shopContent,
         string $jobId,
         string $langIso,
-        int $offset,
         int $limit,
         int $startTime,
         string $dateNow
@@ -125,28 +123,29 @@ class SynchronizationService
             throw new ServiceNotFoundException($serviceId);
         }
 
-        $data = $shopContentApiService->getContentsForFull($offset, $limit, $langIso);
+        $lastSeekKey = $this->syncRepository->getLastSeekKey($shopContent, $langIso);
+
+        $page = $shopContentApiService->getContentsForFull($lastSeekKey, $limit, $langIso);
+        $data = isset($page['rows']) ? $page['rows'] : [];
+        $newSeekKey = isset($page['lastSeekKey']) ? $page['lastSeekKey'] : $lastSeekKey;
+        $remainingObjects = (int) $shopContentApiService->getFullSyncContentLeft($newSeekKey, $langIso);
 
         CommonService::convertDateFormat($data);
 
         if (!empty($data)) {
             $response = $this->cloudSyncClient->upload($jobId, $data, $startTime, true);
 
-            if ($response['httpCode'] == 201) {
-                $offset += $limit;
+            if ($response['httpCode'] != 201) {
+                $newSeekKey = $lastSeekKey;
+                $remainingObjects = max($remainingObjects, 1);
             }
         }
 
-        $remainingObjects = (int) $shopContentApiService->getFullSyncContentLeft($offset, $limit, $langIso);
+        $fullSyncFinished = $remainingObjects <= 0;
 
-        if ($remainingObjects <= 0) {
-            $remainingObjects = 0;
-            $offset = 0;
-        }
+        $this->syncRepository->upsertTypeSync($shopContent, $dateNow, $fullSyncFinished, $langIso, $fullSyncFinished ? null : $newSeekKey);
 
-        $this->syncRepository->upsertTypeSync($shopContent, $offset, $dateNow, $remainingObjects === 0, $langIso);
-
-        return $this->returnSyncResponse($data, $response, $remainingObjects);
+        return $this->returnSyncResponse($data, $response, $fullSyncFinished ? 0 : $remainingObjects);
     }
 
     /**
@@ -268,7 +267,6 @@ class SynchronizationService
                     if ($hasDeleted) {
                         $this->syncRepository->upsertTypeSync(
                             $contentType,
-                            0,
                             $createdAt,
                             false,
                             $this->languagesService->getDefaultLanguageIsoCode()
@@ -287,7 +285,7 @@ class SynchronizationService
 
             foreach ($allIsoCodes as $langIso) {
                 foreach ($contentTypesWithIds as $contentType => $contentIds) {
-                    if ($this->isFullSyncDone($contentType, $langIso)) {
+                    if ($this->isFullSyncDone($contentType, $langIso) || $this->syncRepository->getLastSeekKey($contentType, $langIso) !== null) {
                         if (!is_array($contentIds)) {
                             $contentIds = [$contentIds];
                         }
@@ -308,6 +306,10 @@ class SynchronizationService
                             ];
                         }, $contentIds);
 
+                        $finalContent = array_filter($finalContent, function ($item) use ($contentType, $langIso) {
+                            return $this->shouldRecordIntoOutbox($contentType, $langIso, (string) $item['id_object']);
+                        });
+
                         $contentToInsert = array_merge($contentToInsert, $finalContent);
                     }
                 }
@@ -316,7 +318,7 @@ class SynchronizationService
             $defaultIsoCode = $this->languagesService->getDefaultLanguageIsoCode();
 
             foreach ($contentTypesWithIds as $contentType => $contentIds) {
-                if ($this->isFullSyncDone($contentType, $defaultIsoCode)) {
+                if ($this->isFullSyncDone($contentType, $defaultIsoCode) || $this->syncRepository->getLastSeekKey($contentType, $defaultIsoCode) !== null) {
                     if (!is_array($contentIds)) {
                         $contentIds = [$contentIds];
                     }
@@ -331,6 +333,11 @@ class SynchronizationService
                             'created_at' => $createdAt,
                         ];
                     }, $contentIds);
+
+                    $finalContent = array_filter($finalContent, function ($item) use ($contentType, $defaultIsoCode) {
+                        return $this->shouldRecordIntoOutbox($contentType, $defaultIsoCode, (string) $item['id_object']);
+                    });
+
                     $contentToInsert = array_merge($contentToInsert, $finalContent);
                 }
             }
@@ -377,6 +384,57 @@ class SynchronizationService
     private function isFullSyncDone($shopContent, $langIso)
     {
         return $this->syncRepository->isFullSyncDoneForThisTypeSync($shopContent, $langIso);
+    }
+
+    /**
+     * Record a hook mutation into the outbox when full sync is done, or when
+     * the row's encoded id sits behind the cursor of an in-progress full sync.
+     * Rows ahead of the cursor are skipped: the moving full-sync window will
+     * pick them up.
+     *
+     * @param string $contentType
+     * @param string $langIso
+     * @param string $contentId
+     *
+     * @return bool
+     */
+    private function shouldRecordIntoOutbox($contentType, $langIso, $contentId)
+    {
+        if ($this->isFullSyncDone($contentType, $langIso)) {
+            return true;
+        }
+
+        $lastSeekKey = $this->syncRepository->getLastSeekKey($contentType, $langIso);
+        if ($lastSeekKey === null) {
+            return false;
+        }
+
+        $service = $this->getShopContentService($contentType);
+        if ($service === null) {
+            return false;
+        }
+
+        return strcmp($service->encodeOutboxIdAsSeekKey($contentId), $lastSeekKey) <= 0;
+    }
+
+    /**
+     * @param string $contentType
+     *
+     * @return ShopContentServiceInterface|null
+     */
+    private function getShopContentService($contentType)
+    {
+        $serviceName = str_replace('_', '', ucwords($contentType, '_'));
+        $serviceId = 'PrestaShop\\Module\\PsEventbus\\Service\\ShopContent\\' . $serviceName . 'Service';
+
+        /** @var \Ps_eventbus $module */
+        $module = \Module::getInstanceByName('ps_eventbus');
+
+        try {
+            return $module->getService($serviceId);
+        } catch (ServiceNotFoundException $e) {
+            return null;
+        }
     }
 
     /**

--- a/upgrade/Upgrade-4.1.0.php
+++ b/upgrade/Upgrade-4.1.0.php
@@ -40,7 +40,7 @@ if (!defined('_PS_VERSION_')) {
  */
 function upgrade_module_4_1_0()
 {
-    $db = \Db::getInstance();
+    $db = Db::getInstance();
 
     $hasLastSeekKey = $db->executeS(
         'SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'eventbus_type_sync` LIKE "last_seek_key"'

--- a/upgrade/Upgrade-4.1.0.php
+++ b/upgrade/Upgrade-4.1.0.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Switches eventbus_type_sync from offset to seek pagination:
+ *  - adds `last_seek_key` (the new cursor)
+ *  - drops the now-unused `offset` column
+ *  - resets any in-progress full sync so the new cursor restarts cleanly
+ *
+ * Pre-4.1.0 syncs lost mid-sync changes to already-uploaded rows, so a
+ * fresh full sync is the safest heal for shops still mid-sync at upgrade.
+ *
+ * @return bool
+ */
+function upgrade_module_4_1_0()
+{
+    $db = \Db::getInstance();
+
+    $hasLastSeekKey = $db->executeS(
+        'SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'eventbus_type_sync` LIKE "last_seek_key"'
+    );
+
+    if (empty($hasLastSeekKey)) {
+        $db->execute(
+            'ALTER TABLE `' . _DB_PREFIX_ . 'eventbus_type_sync`
+             ADD COLUMN `last_seek_key` VARCHAR(190) DEFAULT NULL'
+        );
+    }
+
+    $db->execute(
+        'UPDATE `' . _DB_PREFIX_ . 'eventbus_type_sync`
+         SET `last_seek_key` = NULL
+         WHERE `full_sync_finished` = 0'
+    );
+
+    $hasOffset = $db->executeS(
+        'SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'eventbus_type_sync` LIKE "offset"'
+    );
+
+    if (!empty($hasOffset)) {
+        $db->execute(
+            'ALTER TABLE `' . _DB_PREFIX_ . 'eventbus_type_sync`
+             DROP COLUMN `offset`'
+        );
+    }
+
+    return true;
+}

--- a/upgrade/Upgrade-4.1.0.php
+++ b/upgrade/Upgrade-4.1.0.php
@@ -29,12 +29,8 @@ if (!defined('_PS_VERSION_')) {
 
 /**
  * Switches eventbus_type_sync from offset to seek pagination:
- *  - adds `last_seek_key` (the new cursor)
+ *  - adds `last_seek_key` (the new cursor, starts NULL for every row)
  *  - drops the now-unused `offset` column
- *  - resets any in-progress full sync so the new cursor restarts cleanly
- *
- * Pre-4.1.0 syncs lost mid-sync changes to already-uploaded rows, so a
- * fresh full sync is the safest heal for shops still mid-sync at upgrade.
  *
  * @return bool
  */
@@ -52,12 +48,6 @@ function upgrade_module_4_1_0()
              ADD COLUMN `last_seek_key` VARCHAR(190) DEFAULT NULL'
         );
     }
-
-    $db->execute(
-        'UPDATE `' . _DB_PREFIX_ . 'eventbus_type_sync`
-         SET `last_seek_key` = NULL
-         WHERE `full_sync_finished` = 0'
-    );
 
     $hasOffset = $db->executeS(
         'SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'eventbus_type_sync` LIKE "offset"'

--- a/upgrade/Upgrade-4.1.0.php
+++ b/upgrade/Upgrade-4.1.0.php
@@ -38,27 +38,11 @@ function upgrade_module_4_1_0()
 {
     $db = Db::getInstance();
 
-    $hasLastSeekKey = $db->executeS(
-        'SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'eventbus_type_sync` LIKE "last_seek_key"'
+    $db->execute(
+        'ALTER TABLE `' . _DB_PREFIX_ . 'eventbus_type_sync`
+          ADD COLUMN `last_seek_key` VARCHAR(190) DEFAULT NULL
+          DROP COLUMN `offset`'
     );
-
-    if (empty($hasLastSeekKey)) {
-        $db->execute(
-            'ALTER TABLE `' . _DB_PREFIX_ . 'eventbus_type_sync`
-             ADD COLUMN `last_seek_key` VARCHAR(190) DEFAULT NULL'
-        );
-    }
-
-    $hasOffset = $db->executeS(
-        'SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'eventbus_type_sync` LIKE "offset"'
-    );
-
-    if (!empty($hasOffset)) {
-        $db->execute(
-            'ALTER TABLE `' . _DB_PREFIX_ . 'eventbus_type_sync`
-             DROP COLUMN `offset`'
-        );
-    }
 
     return true;
 }


### PR DESCRIPTION
This PR aims to fix two problems at once :
- a hole exists when data is changed during a full sync : because a full sync can last a long time, items may be synced, then changed before the full sync completes. These items are not added to the outbox and never sent again to cloudsync
- performance becomes slower for large databases because querying with offset+limit forces db to sort and re-read every row before relevant page.

The solution proposed here is to switch to key-based pagination. During full sync, rows with an id below last synced key are added to the outbox, other rows are ignored and sent via full sync.
Key based pagination is also much more efficient to fetch data anywhere in the table, fixing slow fetch operations on large tables.