### PR TITLE
feat: add dashboard page with sync status and health checks

### DIFF
--- a/.config.inte.php
+++ b/.config.inte.php
@@ -4,6 +4,7 @@ return [
     'ps_eventbus.proxy_api_url' => 'https://eventbus-proxy.psessentials-integration.net',
     'ps_eventbus.sync_api_url' => 'https://eventbus-sync.psessentials-integration.net',
     'ps_eventbus.live_sync_api_url' => 'https://api.cloudsync-integration.prestashop.com/live-sync/v1',
+    'ps_eventbus.cloudsync_api_url' => 'https://api.cloudsync-integration.prestashop.com',
     'ps_eventbus.sentry_dsn' => 'https://457f191226df4b8f9a0d7bf6f250bab2@o298402.ingest.sentry.io/6066714',
     'ps_eventbus.sentry_env' => 'integration',
     'ps_eventbus.live_mode_vuejs' => false,

--- a/.config.prod.php
+++ b/.config.prod.php
@@ -4,6 +4,7 @@ return [
     'ps_eventbus.proxy_api_url' => 'https://eventbus-proxy.psessentials.net',
     'ps_eventbus.sync_api_url' => 'https://eventbus-sync.psessentials.net',
     'ps_eventbus.live_sync_api_url' => 'https://api.cloudsync.prestashop.com/live-sync/v1',
+    'ps_eventbus.cloudsync_api_url' => 'https://api.cloudsync.prestashop.com',
     'ps_eventbus.sentry_dsn' => 'https://457f191226df4b8f9a0d7bf6f250bab2@o298402.ingest.sentry.io/6066714',
     'ps_eventbus.sentry_env' => 'production',
     'ps_eventbus.live_mode_vuejs' => false,

--- a/config.php
+++ b/config.php
@@ -24,5 +24,6 @@ return [
     'ps_eventbus.live_sync_api_url' => 'http://reverse-proxy/live-sync-api/v1',
     'ps_eventbus.sentry_dsn' => 'https://sentry-id@stuff.ingest.sentry.io/stuff',
     'ps_eventbus.sentry_env' => 'development',
+    'ps_eventbus.cloudsync_api_url' => 'https://api.cloudsync.prestashop.com',
     'ps_eventbus.live_mode_vuejs' => true,
 ];

--- a/controllers/admin/AdminPsEventbusController.php
+++ b/controllers/admin/AdminPsEventbusController.php
@@ -1,10 +1,15 @@
 <?php
 
+use PrestaShop\Module\PsEventbus\Config\Config;
+use PrestaShop\Module\PsEventbus\Service\ApiHealthCheckService;
+use PrestaShop\Module\PsEventbus\Service\PsAccountsAdapterService;
+
 class AdminPsEventbusController extends ModuleAdminController
 {
     /** @var Ps_eventbus */
     public $module;
 
+    /** @var string */
     public $isoCode;
 
     public function __construct()
@@ -26,7 +31,7 @@ class AdminPsEventbusController extends ModuleAdminController
         $link = $this->context->link;
 
         $liveModeVuejs = (bool) $this->module->getServiceContainer()->getParameterWithDefault('ps_eventbus.live_mode_vuejs', 'false');
-        
+
         $moduleBaseUrl = $this->getModuleBaseUrl();
 
         Media::addJsDef([
@@ -35,6 +40,9 @@ class AdminPsEventbusController extends ModuleAdminController
                 'eventbusAjaxPath' => $link->getAdminLink('AdminPsEventbus'),
                 'logoUrl' => $moduleBaseUrl . 'logo.png',
                 'moduleVersion' => $this->module->version,
+                'healthCheckUrl' => $link->getModuleLink('ps_eventbus', 'apiHealthCheck'),
+                'shopContents' => Config::SHOP_CONTENTS,
+                'shopId' => $this->getShopId(),
             ],
         ]);
 
@@ -68,6 +76,60 @@ class AdminPsEventbusController extends ModuleAdminController
         $domain = $ssl ? $shop->domain_ssl : $shop->domain;
 
         return ($ssl ? 'https://' : 'http://') . $domain . $shop->getBaseURI() . 'modules/' . $this->module->name . '/';
+    }
+
+    /**
+     * @return string
+     */
+    private function getShopId()
+    {
+        try {
+            /** @var PsAccountsAdapterService $psAccounts */
+            $psAccounts = $this->module->getService(PsAccountsAdapterService::class);
+
+            return $psAccounts->getShopUuid();
+        } catch (Exception $e) {
+            return '';
+        }
+    }
+
+    /**
+     * AJAX action: return the health check data.
+     *
+     * @return void
+     */
+    public function ajaxProcessGetHealthCheck()
+    {
+        // With display_errors on (dev mode), PHP notices raised while building the
+        // service are written to the response body and corrupt the JSON payload.
+        $displayErrors = ini_get('display_errors');
+        ini_set('display_errors', '0');
+        ob_start();
+
+        try {
+            /** @var ApiHealthCheckService $healthCheckService */
+            $healthCheckService = $this->module->getService(ApiHealthCheckService::class);
+            $response = $healthCheckService->getDashboardHealthCheck();
+        } catch (Exception $e) {
+            $response = [
+                'error' => true,
+                'message' => $e->getMessage(),
+            ];
+        }
+
+        ob_end_clean();
+        ini_set('display_errors', (string) $displayErrors);
+
+        // Not ajaxDie(): it was removed in PrestaShop 9, and ajaxRender() does not
+        // exist in 1.6, which this module still supports.
+        if (!headers_sent()) {
+            header('Content-Type: application/json');
+            header('Cache-Control: no-store, no-cache, must-revalidate');
+        }
+
+        echo (string) json_encode($response);
+
+        exit;
     }
 
     /**

--- a/controllers/admin/AdminPsEventbusController.php
+++ b/controllers/admin/AdminPsEventbusController.php
@@ -45,7 +45,7 @@ class AdminPsEventbusController extends ModuleAdminController
                 'shopContents' => Config::SHOP_CONTENTS,
                 'shopId' => $this->getShopId(),
                 'mockMode' => true,
-                'cloudsyncApiUrl' => 'https://api.cloudsync.prestashop.com',
+                'cloudsyncApiUrl' => $this->module->getServiceContainer()->getParameter('ps_eventbus.cloudsync_api_url'),
             ],
         ]);
 
@@ -82,17 +82,18 @@ class AdminPsEventbusController extends ModuleAdminController
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     private function getShopId()
     {
         try {
             /** @var PsAccountsAdapterService $psAccounts */
             $psAccounts = $this->module->getService(PsAccountsAdapterService::class);
+            $uuid = $psAccounts->getShopUuid();
 
-            return $psAccounts->getShopUuid();
+            return $uuid !== '' ? $uuid : null;
         } catch (Exception $e) {
-            return '';
+            return null;
         }
     }
 

--- a/controllers/admin/AdminPsEventbusController.php
+++ b/controllers/admin/AdminPsEventbusController.php
@@ -17,7 +17,7 @@ class AdminPsEventbusController extends ModuleAdminController
         parent::__construct();
         $this->bootstrap = true;
 
-        /** @phpstan-ignore ternary.alwaysTrue */
+        /* @phpstan-ignore ternary.alwaysTrue */
         $this->isoCode = $this->context->language ? $this->context->language->iso_code : 'en';
     }
 

--- a/controllers/admin/AdminPsEventbusController.php
+++ b/controllers/admin/AdminPsEventbusController.php
@@ -17,6 +17,7 @@ class AdminPsEventbusController extends ModuleAdminController
         parent::__construct();
         $this->bootstrap = true;
 
+        /** @phpstan-ignore ternary.alwaysTrue */
         $this->isoCode = $this->context->language ? $this->context->language->iso_code : 'en';
     }
 
@@ -43,6 +44,8 @@ class AdminPsEventbusController extends ModuleAdminController
                 'healthCheckUrl' => $link->getModuleLink('ps_eventbus', 'apiHealthCheck'),
                 'shopContents' => Config::SHOP_CONTENTS,
                 'shopId' => $this->getShopId(),
+                'mockMode' => true,
+                'cloudsyncApiUrl' => 'https://api.cloudsync.prestashop.com',
             ],
         ]);
 

--- a/e2e-env/docker-compose.yml
+++ b/e2e-env/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     volumes:
       - ..:/var/www/html/modules/ps_eventbus:rw
       - ./init-scripts/install-ps-eventbus.sh:/tmp/init-scripts/install-ps-eventbus.sh:ro
+      - ./nginx-cloudflared.conf:/etc/nginx/nginx.conf:ro
       # Notice: you might enable this if your uid is not 1000, or encounter permission issues
       # - /var/www/html/modules/ps_eventbus/vendor
       # - /var/www/html/modules/ps_eventbus/tools/vendor
@@ -130,7 +131,7 @@ services:
 
   cloudflared:
     image: cloudflare/cloudflared:latest
-    command: tunnel run $${TUNNEL_NAME}
+    command: tunnel run ${TUNNEL_NAME}
     environment:
       - TUNNEL_CRED_FILE=/credentials.json
       - TUNNEL_URL=http://prestashop-exposed:80

--- a/e2e-env/init-scripts/install-ps-eventbus.sh
+++ b/e2e-env/init-scripts/install-ps-eventbus.sh
@@ -16,12 +16,24 @@ ps_eventbus_install() {
   # Notice: you might enable this if your uid is not 1000, or encounter permission issues
   # composer install -n -d ./modules/ps_eventbus
   cd "$PS_FOLDER"
-  # Some flashlight images ship ps_eventbus pre-installed with a stale schema
-  # (e.g. missing last_seek_key). Uninstall first so install.sql runs fresh.
-  echo "* [ps_eventbus] uninstalling any pre-baked version..."
-  php -d memory_limit=-1 bin/console prestashop:module --no-interaction uninstall "ps_eventbus" || true
-  echo "* [ps_eventbus] installing the module..."
-  php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "ps_eventbus"
+
+  # Detect PS version to choose the right CLI syntax.
+  # PS 1.6 flashlight ships a polyfill bin/console that only understands
+  # "prestashop:module install <name>" (no --no-interaction, no uninstall).
+  PS_VERSION=$(php -r "require 'config/settings.inc.php'; echo _PS_VERSION_;")
+  IS_16=$(php -r "echo version_compare('$PS_VERSION', '1.7', '<') ? '1' : '0';")
+
+  if [ "$IS_16" = "1" ]; then
+    echo "* [ps_eventbus] PS $PS_VERSION detected — installing module..."
+    php -d memory_limit=-1 bin/console prestashop:module install ps_eventbus
+  else
+    # Some flashlight images ship ps_eventbus pre-installed with a stale schema
+    # (e.g. missing last_seek_key). Uninstall first so install.sql runs fresh.
+    echo "* [ps_eventbus] uninstalling any pre-baked version..."
+    php -d memory_limit=-1 bin/console prestashop:module --no-interaction uninstall "ps_eventbus" || true
+    echo "* [ps_eventbus] installing the module..."
+    php -d memory_limit=-1 bin/console prestashop:module --no-interaction install "ps_eventbus"
+  fi
 }
 
 ps_eventbus_install

--- a/e2e-env/nginx-cloudflared.conf
+++ b/e2e-env/nginx-cloudflared.conf
@@ -1,0 +1,192 @@
+worker_processes  1;
+pid /var/run/nginx/nginx.pid;
+
+## only when running as root
+#user www-data www-data;
+
+events {
+	worker_connections  1024;
+}
+
+http {
+  include       mime.types;
+  default_type  application/octet-stream;
+
+  sendfile        on;
+  keepalive_timeout  65;
+
+  error_log  /dev/stderr notice;
+  access_log /dev/stdout;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_types
+    application/atom+xml
+    application/geo+json
+    application/javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rdf+xml
+    application/rss+xml
+    application/x-javascript
+    application/xhtml+xml
+    application/xml
+    font/eot
+    font/otf
+    font/ttf
+    image/svg+xml
+    text/css
+    text/javascript
+    text/plain
+    text/xml;
+
+  # Trust X-Forwarded-Proto from cloudflared to set HTTPS correctly
+  map $http_x_forwarded_proto $forwarded_https {
+    https on;
+    default $https;
+  }
+
+  # Source: https://devdocs.prestashop-project.org/8/basics/installation/nginx/
+  # Other optimizasions: https://medium.com/@jituboss/nginx-and-php-fpm-optimization-for-high-traffic-web-applications-f790bf1b30fb
+  server {
+    listen 80;
+    listen 443 ssl;
+    http2 on;
+    server_name localhost;
+    root /var/www/html;
+    index index.php;
+
+    ssl_certificate /usr/local/certs/localhost.crt;
+    ssl_certificate_key /usr/local/certs/localhost-key.key;
+
+    # This should match the `post_max_size` and/or `upload_max_filesize` in your php.ini.
+    client_max_body_size 40M;
+
+    # Uploaded files temporary dir
+    client_body_temp_path /tmp/client_body;
+
+    error_page 404 /index.php?controller=404;
+
+    # Enable browser cache
+    location ~* \.(?:css|eot|gif|ico|jpe?g|otf|png|ttf|woff2?)$ {
+      expires 1d;
+      add_header Cache-Control "public";
+    }
+
+    # Disable logs
+    location = /favicon.ico {
+      access_log off;
+      log_not_found off;
+    }
+
+    location = /admin-dev/robots.txt {
+      access_log off;
+      log_not_found off;
+    }
+
+    # Images
+    rewrite ^/(\d)(-[\w-]+)?/.+\.jpg$ /img/p/$1/$1$2.jpg last;
+    rewrite ^/(\d)(\d)(-[\w-]+)?/.+\.jpg$ /img/p/$1/$2/$1$2$3.jpg last;
+    rewrite ^/(\d)(\d)(\d)(-[\w-]+)?/.+\.jpg$ /img/p/$1/$2/$3/$1$2$3$4.jpg last;
+    rewrite ^/(\d)(\d)(\d)(\d)(-[\w-]+)?/.+\.jpg$ /img/p/$1/$2/$3/$4/$1$2$3$4$5.jpg last;
+    rewrite ^/(\d)(\d)(\d)(\d)(\d)(-[\w-]+)?/.+\.jpg$ /img/p/$1/$2/$3/$4/$5/$1$2$3$4$5$6.jpg last;
+    rewrite ^/(\d)(\d)(\d)(\d)(\d)(\d)(-[\w-]+)?/.+\.jpg$ /img/p/$1/$2/$3/$4/$5/$6/$1$2$3$4$5$6$7.jpg last;
+    rewrite ^/(\d)(\d)(\d)(\d)(\d)(\d)(\d)(-[\w-]+)?/.+\.jpg$ /img/p/$1/$2/$3/$4/$5/$6/$7/$1$2$3$4$5$6$7$8.jpg last;
+    rewrite ^/(\d)(\d)(\d)(\d)(\d)(\d)(\d)(\d)(-[\w-]+)?/.+\.jpg$ /img/p/$1/$2/$3/$4/$5/$6/$7/$8/$1$2$3$4$5$6$7$8$9.jpg last;
+    rewrite ^/c/([\w.-]+)/.+\.jpg$ /img/c/$1.jpg last;
+
+    # AlphaImageLoader for IE and FancyBox.
+    rewrite ^images_ie/?([^/]+)\.(gif|jpe?g|png)$ js/jquery/plugins/fancybox/images/$1.$2 last;
+
+    # Web service API.
+    rewrite ^/api/?(.*)$ /webservice/dispatcher.php?url=$1 last;
+
+    # PrestaShop legacy admin URL
+    location = /ps-admin {
+      rewrite ^ $scheme://$http_host/admin-dev/index.php redirect;
+    }
+
+    location /ps-admin/ {
+      if (!-e $request_filename) {
+        rewrite ^ /admin-dev/index.php last;
+      }
+    }
+
+    # PrestaShop admin URL
+    location = /admin-dev {
+      rewrite ^ $scheme://$http_host/admin-dev/index.php redirect;
+    }
+
+    location /admin-dev/ {
+      if (!-e $request_filename) {
+        rewrite ^ /admin-dev/index.php last;
+      }
+    }
+
+    location / {
+      try_files $uri $uri/ /index.php$is_args$args;
+    }
+
+    # .htaccess, .DS_Store, .htpasswd, etc.
+    location ~ /\.(?!well-known) {
+      deny all;
+    }
+
+    # Source code directories.
+    location ~ ^/(app|bin|cache|classes|config|controllers|docs|localization|override|src|tests|tools|translations|var|vendor)/ {
+      deny all;
+    }
+
+    # vendor in modules directory.
+    location ~ ^/modules/.*/vendor/ {
+      deny all;
+    }
+
+    # Prevent exposing other sensitive files.
+    location ~ \.(log|tpl|twig|sass|yml)$ {
+      deny all;
+    }
+
+    # Prevent injection of PHP files.
+    location /img {
+      location ~ \.php$ { deny all; }
+    }
+
+    location /upload {
+      location ~ \.php$ { deny all; }
+    }
+
+    location ~ \.php$ {
+      try_files $fastcgi_script_name =404;
+
+      include fastcgi_params;
+      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+      fastcgi_param HTTPS $forwarded_https if_not_empty;
+
+      fastcgi_index index.php;
+
+      fastcgi_keep_conn on;
+      fastcgi_read_timeout 30s;
+      fastcgi_send_timeout 30s;
+
+      fastcgi_pass unix:/var/run/php/php-fpm.sock;
+      # Uncomment these in case of long loading or 502/504 errors.
+      # fastcgi_buffer_size 256k;
+      # fastcgi_buffers 256 16k;
+      # fastcgi_busy_buffers_size 256k;
+    }
+
+    # See https://stackoverflow.com/q/43636210
+    location = / {
+      if ($request_method = DELETE) {
+        rewrite ^ /index.php last;
+      }
+      if ($request_method = PUT) {
+        rewrite ^ /index.php last;
+      }
+    }
+  }
+}

--- a/e2e-env/nginx-cloudflared.conf
+++ b/e2e-env/nginx-cloudflared.conf
@@ -53,8 +53,7 @@ http {
   # Other optimizasions: https://medium.com/@jituboss/nginx-and-php-fpm-optimization-for-high-traffic-web-applications-f790bf1b30fb
   server {
     listen 80;
-    listen 443 ssl;
-    http2 on;
+    listen 443 ssl http2;
     server_name localhost;
     root /var/www/html;
     index index.php;

--- a/e2e-env/nginx-cloudflared.conf
+++ b/e2e-env/nginx-cloudflared.conf
@@ -43,10 +43,11 @@ http {
     text/plain
     text/xml;
 
-  # Trust X-Forwarded-Proto from cloudflared to set HTTPS correctly
-  map $http_x_forwarded_proto $forwarded_https {
-    https on;
-    default $https;
+  # This config is only mounted behind cloudflared, where all traffic
+  # originates from Cloudflare over HTTPS. Force HTTPS unconditionally
+  # so PrestaShop never redirects in a loop.
+  map $uri $forwarded_https {
+    default on;
   }
 
   # Source: https://devdocs.prestashop-project.org/8/basics/installation/nginx/

--- a/frontend/js/api/cloudsync-api.js
+++ b/frontend/js/api/cloudsync-api.js
@@ -25,19 +25,26 @@ export async function fetchSyncSummary(baseUrl, shopId) {
 }
 
 /**
+ * Retrieve the shop URL registered in CloudSync so the dashboard can compare
+ * it with the one from ps_accounts.
+ *
+ * Uses the shop-sync-setup endpoint which returns a `targetUrl` attribute.
+ *
  * @param {string} baseUrl  CloudSync API root (no trailing slash)
  * @param {string} shopId   Shop UUID from ps_accounts
  *
  * @returns {Promise<{shopUrl: string}>}
  */
 export async function fetchCloudsyncStatus(baseUrl, shopId) {
-  const response = await fetch(`${baseUrl}/v1/reporting/shop-status/${encodeURIComponent(shopId)}`)
+  const response = await fetch(`${baseUrl}/v1/shop-sync-setup/${encodeURIComponent(shopId)}`)
 
   if (!response.ok) {
-    throw new Error(`CloudSync API error: GET shop-status returned HTTP ${response.status}`)
+    throw new Error(`CloudSync API error: GET shop-sync-setup returned HTTP ${response.status}`)
   }
 
-  return response.json()
+  const data = await response.json()
+
+  return { shopUrl: data.targetUrl || '' }
 }
 
 /**

--- a/frontend/js/api/cloudsync-api.js
+++ b/frontend/js/api/cloudsync-api.js
@@ -1,0 +1,64 @@
+/**
+ * CloudSync API client — definitive fetch calls.
+ *
+ * Every function targets a real CloudSync endpoint. When the endpoints are not
+ * yet deployed, the mock-interceptor wraps these calls and returns canned JSON
+ * instead.
+ */
+
+/**
+ * @param {string} baseUrl  CloudSync API root (no trailing slash)
+ * @param {string} shopId   Shop UUID from ps_accounts
+ *
+ * @returns {Promise<Array<{shopContent: string, requested: boolean, firstSyncFinishedAt: string|null, lastSyncFinishedAt: string|null, httpStatus: number|null, httpStatusText: string|null}>>}
+ *
+ * @see https://docs.cloudsync.prestashop.com/api-doc/reporting-api
+ */
+export async function fetchSyncSummary(baseUrl, shopId) {
+  const response = await fetch(`${baseUrl}/v1/reporting/shop-sync-summary/${encodeURIComponent(shopId)}`)
+
+  if (!response.ok) {
+    throw new Error(`CloudSync API error: GET shop-sync-summary returned HTTP ${response.status}`)
+  }
+
+  return response.json()
+}
+
+/**
+ * @param {string} baseUrl  CloudSync API root (no trailing slash)
+ * @param {string} shopId   Shop UUID from ps_accounts
+ *
+ * @returns {Promise<{shopUrl: string}>}
+ */
+export async function fetchCloudsyncStatus(baseUrl, shopId) {
+  const response = await fetch(`${baseUrl}/v1/reporting/shop-status/${encodeURIComponent(shopId)}`)
+
+  if (!response.ok) {
+    throw new Error(`CloudSync API error: GET shop-status returned HTTP ${response.status}`)
+  }
+
+  return response.json()
+}
+
+/**
+ * Ask CloudSync to call the shop's health check from the outside.
+ *
+ * @param {string} baseUrl         CloudSync API root (no trailing slash)
+ * @param {string} shopId          Shop UUID from ps_accounts
+ * @param {string} healthCheckUrl  Public URL of the shop's health check controller
+ *
+ * @returns {Promise<{probedUrl: string, reachable: boolean, httpStatus: number|null, blockedBy: string|null}>}
+ */
+export async function requestServerAccessCheck(baseUrl, shopId, healthCheckUrl) {
+  const response = await fetch(`${baseUrl}/v1/shop/${encodeURIComponent(shopId)}/server-access-check`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ healthCheckUrl }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`CloudSync API error: POST server-access-check returned HTTP ${response.status}`)
+  }
+
+  return response.json()
+}

--- a/frontend/js/api/mock-data.js
+++ b/frontend/js/api/mock-data.js
@@ -5,12 +5,6 @@
 const MOCK_NOT_REQUESTED = ['wishlists', 'wishlist_products', 'employees', 'translations', 'taxonomies', 'stock_movements']
 
 /**
- * Contents whose last upload failed. Mocked selection, for the sake of the
- * example.
- */
-const MOCK_FAILED = {}
-
-/**
  * Mock sync summary matching the Reporting API schema:
  * GET /v1/reporting/shop-sync-summary/{shopId}
  *
@@ -37,8 +31,6 @@ export function getMockSyncSummary(shopContents) {
       }
     }
 
-    const failure = MOCK_FAILED[shopContent]
-
     // First half of requested contents have finished their initial sync,
     // the rest have not yet — this puts globalSyncStatus into 'syncing'.
     const finished = index < shopContents.length / 2
@@ -52,38 +44,4 @@ export function getMockSyncSummary(shopContents) {
       httpStatusText: finished ? 'OK' : null,
     }
   })
-}
-
-/**
- * Mock of the shop URL CloudSync actually synchronizes with, compared against
- * the one registered in PrestaShop Account to detect a mismatch. No endpoint
- * serves it yet.
- */
-export function getMockCloudsyncStatus(accountsShopUrl) {
-  return {
-    // Mirrors the Account URL so the check reads "Match" until a real endpoint
-    // provides the URL CloudSync is actually configured with.
-    shopUrl: accountsShopUrl,
-  }
-}
-
-/**
- * Mock of the round trip that asks CloudSync to call the shop's health check
- * front controller from the outside and report back whether it got through.
- *
- * This has to be triggered from CloudSync rather than from the browser: only a
- * request coming from CloudSync's own network can reveal that a WAF, a firewall
- * or a Cloudflare challenge stands between the two. The endpoint does not exist
- * yet, so the shape of the request and of the answer below is provisional.
- */
-export async function requestMockServerAccessCheck(healthCheckUrl) {
-  await new Promise((resolve) => setTimeout(resolve, 1200))
-
-  return {
-    // Echoed back so the UI can show which URL was probed
-    probedUrl: healthCheckUrl,
-    reachable: false,
-    httpStatus: 403,
-    blockedBy: 'Cloudflare',
-  }
 }

--- a/frontend/js/api/mock-data.js
+++ b/frontend/js/api/mock-data.js
@@ -1,0 +1,89 @@
+/**
+ * Contents no third-party module asked for, so CloudSync never collects them.
+ * Mocked selection, for the sake of the example.
+ */
+const MOCK_NOT_REQUESTED = ['wishlists', 'wishlist_products', 'employees', 'translations', 'taxonomies', 'stock_movements']
+
+/**
+ * Contents whose last upload failed. Mocked selection, for the sake of the
+ * example.
+ */
+const MOCK_FAILED = {}
+
+/**
+ * Mock sync summary matching the Reporting API schema:
+ * GET /v1/reporting/shop-sync-summary/{shopId}
+ *
+ * Each item: { shopContent, requested, firstSyncFinishedAt, lastSyncFinishedAt,
+ * httpStatus, httpStatusText }. The HTTP status is the result of the last upload
+ * to the CloudSync cloud. `requested` is false when no third-party module
+ * subscribed to that content, in which case it is never synchronized at all.
+ *
+ * @see https://docs.cloudsync.prestashop.com/api-doc/reporting-api
+ */
+export function getMockSyncSummary(shopContents) {
+  const now = Date.now()
+  const day = 86400000
+
+  return shopContents.map((shopContent, index) => {
+    if (MOCK_NOT_REQUESTED.includes(shopContent)) {
+      return {
+        shopContent,
+        requested: false,
+        firstSyncFinishedAt: null,
+        lastSyncFinishedAt: null,
+        httpStatus: null,
+        httpStatusText: null,
+      }
+    }
+
+    const failure = MOCK_FAILED[shopContent]
+
+    // First half of requested contents have finished their initial sync,
+    // the rest have not yet — this puts globalSyncStatus into 'syncing'.
+    const finished = index < shopContents.length / 2
+
+    return {
+      shopContent,
+      requested: true,
+      firstSyncFinishedAt: finished ? new Date(now - day * 3).toISOString() : null,
+      lastSyncFinishedAt: finished ? new Date(now - 60000 * (index + 1)).toISOString() : null,
+      httpStatus: finished ? 200 : null,
+      httpStatusText: finished ? 'OK' : null,
+    }
+  })
+}
+
+/**
+ * Mock of the shop URL CloudSync actually synchronizes with, compared against
+ * the one registered in PrestaShop Account to detect a mismatch. No endpoint
+ * serves it yet.
+ */
+export function getMockCloudsyncStatus(accountsShopUrl) {
+  return {
+    // Mirrors the Account URL so the check reads "Match" until a real endpoint
+    // provides the URL CloudSync is actually configured with.
+    shopUrl: accountsShopUrl,
+  }
+}
+
+/**
+ * Mock of the round trip that asks CloudSync to call the shop's health check
+ * front controller from the outside and report back whether it got through.
+ *
+ * This has to be triggered from CloudSync rather than from the browser: only a
+ * request coming from CloudSync's own network can reveal that a WAF, a firewall
+ * or a Cloudflare challenge stands between the two. The endpoint does not exist
+ * yet, so the shape of the request and of the answer below is provisional.
+ */
+export async function requestMockServerAccessCheck(healthCheckUrl) {
+  await new Promise((resolve) => setTimeout(resolve, 1200))
+
+  return {
+    // Echoed back so the UI can show which URL was probed
+    probedUrl: healthCheckUrl,
+    reachable: false,
+    httpStatus: 403,
+    blockedBy: 'Cloudflare',
+  }
+}

--- a/frontend/js/api/mock-interceptor.js
+++ b/frontend/js/api/mock-interceptor.js
@@ -1,0 +1,57 @@
+/**
+ * API layer that transparently switches between real CloudSync endpoints and
+ * mock data. The store always calls these functions; the `mockMode` flag in
+ * appStore decides which path runs.
+ *
+ * To go live, set `mockMode: false` in the PHP eventbusConfig.
+ */
+import * as realApi from './cloudsync-api'
+import * as mockData from './mock-data'
+import { useAppStore } from '../stores/app-store'
+
+/**
+ * @param {string} baseUrl
+ * @param {string} shopId
+ * @returns {Promise<Array>}
+ */
+export async function fetchSyncSummary(baseUrl, shopId) {
+  const app = useAppStore()
+
+  if (app.mockMode) {
+    return mockData.getMockSyncSummary(app.shopContents)
+  }
+
+  return realApi.fetchSyncSummary(baseUrl, shopId)
+}
+
+/**
+ * @param {string} baseUrl
+ * @param {string} shopId
+ * @param {string} accountsShopUrl  Needed by the mock to mirror the Account URL
+ * @returns {Promise<{shopUrl: string}>}
+ */
+export async function fetchCloudsyncStatus(baseUrl, shopId, accountsShopUrl) {
+  const app = useAppStore()
+
+  if (app.mockMode) {
+    return mockData.getMockCloudsyncStatus(accountsShopUrl)
+  }
+
+  return realApi.fetchCloudsyncStatus(baseUrl, shopId)
+}
+
+/**
+ * @param {string} baseUrl
+ * @param {string} shopId
+ * @param {string} healthCheckUrl
+ * @returns {Promise<{probedUrl: string, reachable: boolean, httpStatus: number|null, blockedBy: string|null}>}
+ */
+export async function requestServerAccessCheck(baseUrl, shopId, healthCheckUrl) {
+  const app = useAppStore()
+
+  if (app.mockMode) {
+    return mockData.requestMockServerAccessCheck(healthCheckUrl)
+  }
+
+  return realApi.requestServerAccessCheck(baseUrl, shopId, healthCheckUrl)
+}

--- a/frontend/js/api/mock-interceptor.js
+++ b/frontend/js/api/mock-interceptor.js
@@ -3,7 +3,9 @@
  * mock data. The store always calls these functions; the `mockMode` flag in
  * appStore decides which path runs.
  *
- * To go live, set `mockMode: false` in the PHP eventbusConfig.
+ * Connections and CloudSync status always hit the real Sync API (authenticated
+ * with the Accounts token server-side). The Reporting API endpoints remain
+ * mocked until they are deployed.
  */
 import * as realApi from './cloudsync-api'
 import * as mockData from './mock-data'
@@ -25,18 +27,14 @@ export async function fetchSyncSummary(baseUrl, shopId) {
 }
 
 /**
+ * Always uses the real Sync API — the shop-sync-setup endpoint returns the
+ * targetUrl attribute that CloudSync synchronizes with.
+ *
  * @param {string} baseUrl
  * @param {string} shopId
- * @param {string} accountsShopUrl  Needed by the mock to mirror the Account URL
  * @returns {Promise<{shopUrl: string}>}
  */
-export async function fetchCloudsyncStatus(baseUrl, shopId, accountsShopUrl) {
-  const app = useAppStore()
-
-  if (app.mockMode) {
-    return mockData.getMockCloudsyncStatus(accountsShopUrl)
-  }
-
+export async function fetchCloudsyncStatus(baseUrl, shopId) {
   return realApi.fetchCloudsyncStatus(baseUrl, shopId)
 }
 
@@ -47,11 +45,5 @@ export async function fetchCloudsyncStatus(baseUrl, shopId, accountsShopUrl) {
  * @returns {Promise<{probedUrl: string, reachable: boolean, httpStatus: number|null, blockedBy: string|null}>}
  */
 export async function requestServerAccessCheck(baseUrl, shopId, healthCheckUrl) {
-  const app = useAppStore()
-
-  if (app.mockMode) {
-    return mockData.requestMockServerAccessCheck(healthCheckUrl)
-  }
-
   return realApi.requestServerAccessCheck(baseUrl, shopId, healthCheckUrl)
 }

--- a/frontend/js/components/dashboard/health-check-item.vue
+++ b/frontend/js/components/dashboard/health-check-item.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="health-check-item">
+    <PuikIcon :icon="icon" :class="['health-check-item__icon', `health-check-item__icon--${props.status}`]" />
+    <div class="health-check-item__text">
+      <span class="health-check-item__label">
+        {{ $t(`dashboard.healthCheck.checks.${props.id}.label`) }}
+        <span v-if="hint" class="health-check-item__hint">{{ hint }}</span>
+      </span>
+      <span v-if="props.detail" class="health-check-item__detail">{{ props.detail }}</span>
+    </div>
+    <div class="health-check-item__aside">
+      <PuikTag v-if="props.badge" :content="$t(`dashboard.healthCheck.badges.${props.badge}`)" :variant="tagVariant" />
+      <PuikButton v-if="props.action" variant="tertiary" size="sm" :loading="props.actionLoading" :disabled="props.actionLoading" @click="emit('action')">
+        {{ $t(`dashboard.healthCheck.checks.${props.id}.action`) }}
+      </PuikButton>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { computed } from 'vue'
+  import { useI18n } from 'vue-i18n'
+  import { PuikIcon, PuikTag, PuikButton } from '@prestashopcorp/puik-components'
+
+  const { t, te } = useI18n()
+
+  const props = defineProps({
+    id: { type: String, required: true },
+    status: { type: String, default: 'ok' },
+    badge: { type: String, default: '' },
+    detail: { type: String, default: '' },
+    action: { type: Boolean, default: false },
+    actionLoading: { type: Boolean, default: false },
+  })
+
+  const emit = defineEmits(['action'])
+
+  const icons = {
+    ok: 'check_circle',
+    warning: 'warning',
+    error: 'cancel',
+    idle: 'help',
+  }
+
+  // PuikTag only ships colour names, not semantic variants
+  const variants = {
+    ok: 'green',
+    warning: 'yellow',
+    error: 'neutral',
+    idle: 'neutral',
+  }
+
+  const icon = computed(() => icons[props.status] ?? icons.ok)
+  const tagVariant = computed(() => variants[props.status] ?? 'neutral')
+
+  const hint = computed(() => {
+    const key = `dashboard.healthCheck.checks.${props.id}.hint`
+
+    return te(key) ? t(key) : ''
+  })
+</script>
+
+<style lang="scss" scoped>
+  .health-check-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 0;
+    border-bottom: 1px solid $row-border;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &__icon {
+      font-size: 20px;
+      flex-shrink: 0;
+
+      &--ok {
+        color: $status-ok;
+      }
+
+      &--warning {
+        color: $status-warning;
+      }
+
+      &--error {
+        color: $status-error;
+      }
+
+      &--idle {
+        color: $text-secondary;
+      }
+    }
+
+    &__text {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      min-width: 0;
+    }
+
+    &__label {
+      font-size: 14px;
+      color: $text-primary;
+    }
+
+    &__hint {
+      margin-left: 6px;
+      font-size: 13px;
+      color: $text-secondary;
+    }
+
+    &__detail {
+      font-size: 12px;
+      color: $text-secondary;
+    }
+
+    &__aside {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-left: auto;
+      flex-shrink: 0;
+    }
+  }
+</style>

--- a/frontend/js/components/dashboard/health-check-item.vue
+++ b/frontend/js/components/dashboard/health-check-item.vue
@@ -64,7 +64,7 @@
   .health-check-item {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: $row-gap;
     padding: 14px 0;
     border-bottom: 1px solid $row-border;
 
@@ -119,7 +119,7 @@
     &__aside {
       display: flex;
       align-items: center;
-      gap: 12px;
+      gap: $row-gap;
       margin-left: auto;
       flex-shrink: 0;
     }

--- a/frontend/js/components/dashboard/health-check-section.vue
+++ b/frontend/js/components/dashboard/health-check-section.vue
@@ -1,0 +1,58 @@
+<template>
+  <section class="health-check-section">
+    <h3 class="health-check-section__title">
+      <PuikIcon icon="monitor_heart" class="health-check-section__title-icon" />
+      {{ $t('dashboard.healthCheck.title') }}
+    </h3>
+    <PuikSpinnerLoader v-if="dashboardStore.healthCheckLoading" size="md" />
+    <PuikAlert v-else-if="dashboardStore.healthCheckError" variant="danger">
+      {{ dashboardStore.healthCheckError }}
+    </PuikAlert>
+    <div v-else class="health-check-section__list">
+      <HealthCheckItem
+        v-for="check in dashboardStore.healthChecks"
+        :key="check.id"
+        :id="check.id"
+        :status="check.status"
+        :badge="check.badge"
+        :detail="check.detail"
+        :action="!!check.action"
+        :action-loading="!!check.actionLoading"
+        @action="runCheckAction(check)"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup>
+  import { PuikIcon, PuikSpinnerLoader, PuikAlert } from '@prestashopcorp/puik-components'
+  import { useDashboardStore } from '../../stores/dashboard-store'
+  import HealthCheckItem from './health-check-item.vue'
+
+  const dashboardStore = useDashboardStore()
+
+  function runCheckAction(check) {
+    if (check.action && typeof dashboardStore[check.action] === 'function') {
+      dashboardStore[check.action]()
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .health-check-section {
+    @include dashboard-card;
+
+    &__title {
+      @include dashboard-card-title;
+    }
+
+    &__title-icon {
+      font-size: 20px;
+      color: $accent;
+    }
+
+    &__list {
+      margin-top: 8px;
+    }
+  }
+</style>

--- a/frontend/js/components/dashboard/sync-status-card.vue
+++ b/frontend/js/components/dashboard/sync-status-card.vue
@@ -1,0 +1,169 @@
+<template>
+  <section class="sync-status-card">
+    <PuikSpinnerLoader v-if="dashboardStore.syncSummaryLoading" size="md" />
+    <PuikAlert v-else-if="dashboardStore.syncSummaryError" variant="danger">
+      {{ dashboardStore.syncSummaryError }}
+    </PuikAlert>
+    <template v-else>
+      <PuikIcon :icon="state.icon" :class="['sync-status-card__icon', `sync-status-card__icon--${state.tone}`]" />
+      <h3 class="sync-status-card__title">{{ state.title }}</h3>
+      <p class="sync-status-card__description">{{ state.description }}</p>
+      <div v-if="state.showProgress" class="sync-status-card__progress">
+        <PuikProgressBar :percentage="dashboardStore.syncProgress" class="sync-status-card__bar" />
+        <span class="sync-status-card__percentage">{{ dashboardStore.syncProgress }}%</span>
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup>
+  import { computed } from 'vue'
+  import { useI18n } from 'vue-i18n'
+  import { PuikIcon, PuikProgressBar, PuikSpinnerLoader, PuikAlert } from '@prestashopcorp/puik-components'
+  import { useDashboardStore } from '../../stores/dashboard-store'
+
+  const { t } = useI18n()
+  const dashboardStore = useDashboardStore()
+
+  const lastSyncedLabel = computed(() => {
+    const ts = dashboardStore.lastSyncedAt
+    if (!ts) return ''
+
+    const diffMin = Math.floor((Date.now() - ts) / 60000)
+    const diffHours = Math.floor(diffMin / 60)
+    const diffDays = Math.floor(diffHours / 24)
+
+    if (diffMin < 1) return t('dashboard.timeAgo.justNow')
+    if (diffMin < 60) return t('dashboard.timeAgo.minutesAgo', { n: diffMin })
+    if (diffHours < 24) return t('dashboard.timeAgo.hoursAgo', { n: diffHours })
+
+    return t('dashboard.timeAgo.daysAgo', { n: diffDays })
+  })
+
+  /**
+   * The card covers the whole lifecycle of the sync:
+   * - initial: first import still running, show the progress bar
+   * - incremental: everything imported, changes are streamed continuously
+   * - failed / offboarded: nothing is flowing
+   */
+  const state = computed(() => {
+    const status = dashboardStore.globalSyncStatus
+
+    if (status === 'syncing') {
+      return {
+        icon: 'rocket_launch',
+        tone: 'accent',
+        title: t('dashboard.syncCard.initial.title'),
+        description: t('dashboard.syncCard.initial.description'),
+        showProgress: true,
+      }
+    }
+
+    if (status === 'synced') {
+      return {
+        icon: 'cloud_done',
+        tone: 'ok',
+        title: t('dashboard.syncCard.incremental.title'),
+        description: lastSyncedLabel.value
+          ? t('dashboard.syncCard.incremental.descriptionWithTime', { time: lastSyncedLabel.value })
+          : t('dashboard.syncCard.incremental.description'),
+        showProgress: false,
+      }
+    }
+
+    if (status === 'failed') {
+      return {
+        icon: 'error',
+        tone: 'error',
+        title: t('dashboard.syncCard.failed.title'),
+        description: t('dashboard.syncCard.failed.description'),
+        showProgress: false,
+      }
+    }
+
+    return {
+      icon: 'cloud_off',
+      tone: 'neutral',
+      title: t('dashboard.syncCard.offboarded.title'),
+      description: t('dashboard.syncCard.offboarded.description'),
+      showProgress: false,
+    }
+  })
+</script>
+
+<style lang="scss" scoped>
+  .sync-status-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 32px 24px 36px;
+    margin-bottom: 24px;
+    background-color: $card-background;
+    border: 1px solid $card-border;
+    border-radius: $card-radius;
+    box-shadow: $card-shadow;
+    text-align: center;
+
+    &__icon {
+      font-size: 32px;
+      margin-bottom: 12px;
+
+      &--accent {
+        color: $accent;
+      }
+
+      &--ok {
+        color: $status-ok;
+      }
+
+      &--error {
+        color: $status-error;
+      }
+
+      &--neutral {
+        color: $text-secondary;
+      }
+    }
+
+    &__title {
+      margin: 0 0 8px;
+      font-size: 15px;
+      font-weight: 700;
+      color: $text-primary;
+    }
+
+    &__description {
+      max-width: 480px;
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.5;
+      color: $text-secondary;
+    }
+
+    &__progress {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      max-width: 380px;
+      margin-top: 24px;
+    }
+
+    // The Puik track has no intrinsic width, so it collapses inside a centered
+    // flex column unless it is stretched explicitly.
+    &__bar {
+      width: 100%;
+
+      :deep(.progress-bar__content) {
+        background-color: $accent;
+      }
+    }
+
+    &__percentage {
+      font-size: 12px;
+      font-weight: 600;
+      color: $text-secondary;
+    }
+  }
+</style>

--- a/frontend/js/components/dashboard/sync-status-card.vue
+++ b/frontend/js/components/dashboard/sync-status-card.vue
@@ -20,7 +20,7 @@
   import { computed } from 'vue'
   import { useI18n } from 'vue-i18n'
   import { PuikIcon, PuikProgressBar, PuikSpinnerLoader, PuikAlert } from '@prestashopcorp/puik-components'
-  import { useDashboardStore } from '../../stores/dashboard-store'
+  import { useDashboardStore, SYNC_STATUS } from '../../stores/dashboard-store'
 
   const { t } = useI18n()
   const dashboardStore = useDashboardStore()
@@ -49,7 +49,7 @@
   const state = computed(() => {
     const status = dashboardStore.globalSyncStatus
 
-    if (status === 'syncing') {
+    if (status === SYNC_STATUS.syncing) {
       return {
         icon: 'rocket_launch',
         tone: 'accent',
@@ -59,7 +59,7 @@
       }
     }
 
-    if (status === 'synced') {
+    if (status === SYNC_STATUS.synced) {
       return {
         icon: 'cloud_done',
         tone: 'ok',
@@ -71,7 +71,7 @@
       }
     }
 
-    if (status === 'failed') {
+    if (status === SYNC_STATUS.failed) {
       return {
         icon: 'error',
         tone: 'error',

--- a/frontend/js/components/dashboard/sync-status-table.vue
+++ b/frontend/js/components/dashboard/sync-status-table.vue
@@ -14,9 +14,9 @@
     </div>
     <ul v-else class="sync-status-table__list">
       <li
-        v-for="item in dashboardStore.syncSummary"
+        v-for="item in dashboardStore.requestedSyncSummary"
         :key="item.shopContent"
-        :class="['sync-status-table__row', { 'sync-status-table__row--muted': item.requested === false }]"
+        class="sync-status-table__row"
       >
         <span class="sync-status-table__content-type">{{ item.shopContent }}</span>
         <PuikTag :content="getStatusLabel(item)" :variant="getStatusVariant(item)" class="sync-status-table__badge" />
@@ -34,7 +34,6 @@
   const dashboardStore = useDashboardStore()
 
   function getStatusVariant(item) {
-    if (item.requested === false) return 'neutral'
     if (!item.httpStatus) return 'neutral'
     if (item.httpStatus >= 400) return 'yellow'
 
@@ -42,8 +41,6 @@
   }
 
   function getStatusLabel(item) {
-    // Nothing was ever collected: no third-party module subscribed to it
-    if (item.requested === false) return t('dashboard.syncTable.notRequested')
     if (!item.httpStatus) return t('dashboard.syncStatus.pending')
 
     return `${item.httpStatus} — ${item.httpStatusText}`
@@ -92,10 +89,6 @@
         border-bottom: none;
       }
 
-      // Nothing is expected from these, so they recede
-      &--muted .sync-status-table__content-type {
-        color: $text-secondary;
-      }
     }
 
     &__content-type {

--- a/frontend/js/components/dashboard/sync-status-table.vue
+++ b/frontend/js/components/dashboard/sync-status-table.vue
@@ -81,14 +81,13 @@
     &__row {
       display: flex;
       align-items: center;
-      gap: 12px;
+      gap: $row-gap;
       padding: 14px 0;
       border-bottom: 1px solid $row-border;
 
       &:last-child {
         border-bottom: none;
       }
-
     }
 
     &__content-type {

--- a/frontend/js/components/dashboard/sync-status-table.vue
+++ b/frontend/js/components/dashboard/sync-status-table.vue
@@ -1,0 +1,111 @@
+<template>
+  <section class="sync-status-table">
+    <h3 class="sync-status-table__title">
+      <PuikIcon icon="sync" class="sync-status-table__title-icon" />
+      {{ $t('dashboard.syncTable.title') }}
+    </h3>
+    <p class="sync-status-table__subtitle">{{ $t('dashboard.syncTable.subtitle') }}</p>
+    <PuikSpinnerLoader v-if="dashboardStore.syncSummaryLoading" size="md" />
+    <PuikAlert v-else-if="dashboardStore.syncSummaryError" variant="danger">
+      {{ dashboardStore.syncSummaryError }}
+    </PuikAlert>
+    <div v-else-if="dashboardStore.syncSummary.length === 0" class="sync-status-table__empty">
+      {{ $t('dashboard.syncTable.empty') }}
+    </div>
+    <ul v-else class="sync-status-table__list">
+      <li
+        v-for="item in dashboardStore.syncSummary"
+        :key="item.shopContent"
+        :class="['sync-status-table__row', { 'sync-status-table__row--muted': item.requested === false }]"
+      >
+        <span class="sync-status-table__content-type">{{ item.shopContent }}</span>
+        <PuikTag :content="getStatusLabel(item)" :variant="getStatusVariant(item)" class="sync-status-table__badge" />
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup>
+  import { PuikIcon, PuikSpinnerLoader, PuikAlert, PuikTag } from '@prestashopcorp/puik-components'
+  import { useI18n } from 'vue-i18n'
+  import { useDashboardStore } from '../../stores/dashboard-store'
+
+  const { t } = useI18n()
+  const dashboardStore = useDashboardStore()
+
+  function getStatusVariant(item) {
+    if (item.requested === false) return 'neutral'
+    if (!item.httpStatus) return 'neutral'
+    if (item.httpStatus >= 400) return 'yellow'
+
+    return 'green'
+  }
+
+  function getStatusLabel(item) {
+    // Nothing was ever collected: no third-party module subscribed to it
+    if (item.requested === false) return t('dashboard.syncTable.notRequested')
+    if (!item.httpStatus) return t('dashboard.syncStatus.pending')
+
+    return `${item.httpStatus} — ${item.httpStatusText}`
+  }
+</script>
+
+<style lang="scss" scoped>
+  .sync-status-table {
+    @include dashboard-card;
+
+    &__title {
+      @include dashboard-card-title;
+    }
+
+    &__title-icon {
+      font-size: 20px;
+      color: $accent;
+    }
+
+    &__subtitle {
+      margin: 6px 0 12px;
+      font-size: 13px;
+      color: $text-secondary;
+    }
+
+    &__empty {
+      padding: 24px;
+      text-align: center;
+      color: $text-secondary;
+    }
+
+    &__list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    &__row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 0;
+      border-bottom: 1px solid $row-border;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      // Nothing is expected from these, so they recede
+      &--muted .sync-status-table__content-type {
+        color: $text-secondary;
+      }
+    }
+
+    &__content-type {
+      font-size: 14px;
+      color: $text-primary;
+    }
+
+    &__badge {
+      margin-left: auto;
+      flex-shrink: 0;
+    }
+  }
+</style>

--- a/frontend/js/components/header/header.vue
+++ b/frontend/js/components/header/header.vue
@@ -65,10 +65,5 @@
       color: $text-secondary;
       line-height: 1.2;
     }
-
-    &__separator {
-      height: 1px;
-      background-color: $card-border;
-    }
   }
 </style>

--- a/frontend/js/components/header/header.vue
+++ b/frontend/js/components/header/header.vue
@@ -1,14 +1,16 @@
 <template>
-  <div class="eventbus-header">
+  <header class="eventbus-header">
     <div class="eventbus-header__content">
-      <img :src="appStore.logoUrl" alt="ps_eventbus" class="eventbus-header__logo" />
+      <span class="eventbus-header__logo-wrapper">
+        <img :src="appStore.logoUrl" alt="ps_eventbus" class="eventbus-header__logo" />
+      </span>
       <div class="eventbus-header__info">
-        <span class="eventbus-header__name">ps_eventbus</span>
+        <span class="eventbus-header__name">{{ $t('header.title') }}</span>
         <span class="eventbus-header__version">v{{ appStore.moduleVersion }}</span>
       </div>
     </div>
     <div class="eventbus-header__separator" />
-  </div>
+  </header>
 </template>
 
 <script setup>
@@ -22,24 +24,38 @@
     &__content {
       display: flex;
       align-items: center;
-      gap: 12px;
-      padding: 20px 24px 16px;
+      gap: 16px;
+      padding: 24px 32px 20px;
+    }
+
+    &__logo-wrapper {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 56px;
+      height: 56px;
+      flex-shrink: 0;
+      border-radius: 50%;
+      background-color: $accent-soft;
     }
 
     &__logo {
-      width: 40px;
-      height: 40px;
+      width: 32px;
+      height: 32px;
       object-fit: contain;
     }
 
     &__info {
       display: flex;
       flex-direction: column;
+      gap: 4px;
     }
 
     &__name {
-      font-size: 16px;
-      font-weight: 600;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
       color: $text-primary;
       line-height: 1.2;
     }
@@ -52,7 +68,7 @@
 
     &__separator {
       height: 1px;
-      background-color: #e0e0e0;
+      background-color: $card-border;
     }
   }
 </style>

--- a/frontend/js/components/navigation-bar/navigation-bar.vue
+++ b/frontend/js/components/navigation-bar/navigation-bar.vue
@@ -1,5 +1,5 @@
 <script setup>
-  import { PuikTabNavigation, PuikTabNavigationGroupTitles, PuikTabNavigationTitle } from '@prestashopcorp/puik-components'
+  import { PuikTabNavigation, PuikTabNavigationGroupTitles, PuikTabNavigationTitle, PuikIcon } from '@prestashopcorp/puik-components'
   import { computed } from 'vue'
   import { useRouter, useRoute } from 'vue-router'
 
@@ -8,13 +8,19 @@
 
   const navigationOrder = ['dashboard', 'connections', 'supportDebug']
 
+  const navigationIcons = {
+    dashboard: 'dashboard',
+    connections: 'handyman',
+    supportDebug: 'bug_report',
+  }
+
   const visibleRoutes = computed(() => {
     const allRoutes = router.getRoutes()
 
     return navigationOrder
       .map((name) => allRoutes.find((r) => r.name === name))
       .filter(Boolean)
-      .map((r, index) => ({ ...r, position: index }))
+      .map((r, index) => ({ ...r, position: index, icon: navigationIcons[r.name] }))
   })
 
   const currentRoutePosition = computed(() => {
@@ -39,7 +45,10 @@
   >
     <PuikTabNavigationGroupTitles aria-label="navigation">
       <PuikTabNavigationTitle v-for="r in visibleRoutes" :key="r.path" :position="r.position">
-        {{ $t(`tabs.${r.name}`) }}
+        <span class="eventbus-tab">
+          <PuikIcon v-if="r.icon" :icon="r.icon" class="eventbus-tab__icon" />
+          {{ $t(`tabs.${r.name}`) }}
+        </span>
       </PuikTabNavigationTitle>
     </PuikTabNavigationGroupTitles>
   </PuikTabNavigation>
@@ -48,6 +57,16 @@
 <style lang="scss" scoped>
   #eventbus-tabs {
     background-color: $background-primary;
-    padding-left: 14px;
+    padding-left: 10px;
+  }
+
+  .eventbus-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+
+    &__icon {
+      font-size: 20px;
+    }
   }
 </style>

--- a/frontend/js/components/navigation-bar/navigation-bar.vue
+++ b/frontend/js/components/navigation-bar/navigation-bar.vue
@@ -57,6 +57,8 @@
 <style lang="scss" scoped>
   #eventbus-tabs {
     background-color: $background-primary;
+    border-bottom: 1px solid $card-border;
+    border-top: 1px solid $card-border;
     padding-left: 10px;
   }
 

--- a/frontend/js/pages/home/home.vue
+++ b/frontend/js/pages/home/home.vue
@@ -1,15 +1,21 @@
 <template>
   <div class="eventbus-page">
-    <h2>{{ $t('pages.dashboard.title') }}</h2>
+    <SyncStatusCard />
+    <HealthCheckSection />
+    <SyncStatusTable />
   </div>
 </template>
 
 <script setup>
-  // Dashboard page
-</script>
+  import { onMounted } from 'vue'
+  import { useDashboardStore } from '../../stores/dashboard-store'
+  import SyncStatusCard from '../../components/dashboard/sync-status-card.vue'
+  import HealthCheckSection from '../../components/dashboard/health-check-section.vue'
+  import SyncStatusTable from '../../components/dashboard/sync-status-table.vue'
 
-<style lang="scss" scoped>
-  .eventbus-page {
-    padding: 24px;
-  }
-</style>
+  const dashboardStore = useDashboardStore()
+
+  onMounted(() => {
+    dashboardStore.loadDashboard()
+  })
+</script>

--- a/frontend/js/pages/index.vue
+++ b/frontend/js/pages/index.vue
@@ -18,11 +18,17 @@
   }
 
   .eventbus-app {
-    background: $background-primary;
     min-height: 200px;
   }
 
   #router-view {
-    padding: 24px;
+    padding: 32px;
+    background: $page-background;
+    border-top: 1px solid $card-border;
+  }
+
+  #vue-app {
+    margin-left: -15px;
+    margin-top: -15px;
   }
 </style>

--- a/frontend/js/pages/index.vue
+++ b/frontend/js/pages/index.vue
@@ -19,16 +19,11 @@
 
   .eventbus-app {
     min-height: 200px;
+    background: $page-background;
   }
 
   #router-view {
     padding: 32px;
-    background: $page-background;
-    border-top: 1px solid $card-border;
-  }
-
-  #vue-app {
-    margin-left: -15px;
-    margin-top: -15px;
+    max-width: 60%;
   }
 </style>

--- a/frontend/js/stores/app-store.js
+++ b/frontend/js/stores/app-store.js
@@ -9,11 +9,8 @@ export const useAppStore = defineStore('app', {
     logoUrl: config.logoUrl ?? '',
     moduleVersion: config.moduleVersion ?? '0.0.0',
     healthCheckUrl: config.healthCheckUrl ?? '',
-    shopId: config.shopId ?? '',
-    // Canonical list from Config::SHOP_CONTENTS, so the dashboard never has to
-    // maintain its own copy
+    shopId: config.shopId ?? null,
     shopContents: config.shopContents ?? [],
-    // When true, API calls return canned mock data instead of hitting CloudSync
     mockMode: config.mockMode ?? true,
     cloudsyncApiUrl: config.cloudsyncApiUrl ?? '',
   }),

--- a/frontend/js/stores/app-store.js
+++ b/frontend/js/stores/app-store.js
@@ -13,5 +13,8 @@ export const useAppStore = defineStore('app', {
     // Canonical list from Config::SHOP_CONTENTS, so the dashboard never has to
     // maintain its own copy
     shopContents: config.shopContents ?? [],
+    // When true, API calls return canned mock data instead of hitting CloudSync
+    mockMode: config.mockMode ?? true,
+    cloudsyncApiUrl: config.cloudsyncApiUrl ?? '',
   }),
 })

--- a/frontend/js/stores/app-store.js
+++ b/frontend/js/stores/app-store.js
@@ -8,5 +8,10 @@ export const useAppStore = defineStore('app', {
     eventbusAjaxPath: config.eventbusAjaxPath ?? '',
     logoUrl: config.logoUrl ?? '',
     moduleVersion: config.moduleVersion ?? '0.0.0',
+    healthCheckUrl: config.healthCheckUrl ?? '',
+    shopId: config.shopId ?? '',
+    // Canonical list from Config::SHOP_CONTENTS, so the dashboard never has to
+    // maintain its own copy
+    shopContents: config.shopContents ?? [],
   }),
 })

--- a/frontend/js/stores/dashboard-store.js
+++ b/frontend/js/stores/dashboard-store.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import i18n from '../i18n'
 import { useAppStore } from './app-store'
 import { fetchSyncSummary, fetchCloudsyncStatus, requestServerAccessCheck } from '../api/mock-interceptor'
 
@@ -8,7 +9,7 @@ import { fetchSyncSummary, fetchCloudsyncStatus, requestServerAccessCheck } from
  * when the latest version could not be determined, in which case no claim is
  * made about it.
  */
-function buildModuleCheck(id, { installed, ready, version, latestVersion, upToDate }) {
+function buildModuleCheck(id, { installed, ready, readyIssue, version, latestVersion, upToDate }) {
   const detail = version ? `v${version}` : ''
 
   if (!installed) {
@@ -16,7 +17,7 @@ function buildModuleCheck(id, { installed, ready, version, latestVersion, upToDa
   }
 
   if (!ready) {
-    return { id, status: 'error', badge: 'ko', detail }
+    return { id, status: 'error', badge: 'ko', detail: readyIssue || detail }
   }
 
   if (upToDate === false) {
@@ -131,16 +132,16 @@ export const useDashboardStore = defineStore('dashboard', {
       return [
         buildModuleCheck('psAccount', {
           installed: psAccount.installed,
-          // ps_accounts is only useful once the shop is linked to an account
           ready: psAccount.linked,
+          readyIssue: i18n.global.t('dashboard.healthCheck.issues.psAccountNotLinked'),
           version: psAccount.version,
           latestVersion: psAccount.latestVersion,
           upToDate: psAccount.upToDate,
         }),
         buildModuleCheck('psEventbus', {
           installed: true,
-          // Its own tables are what make the module operational
           ready: psEventbus.tablesInstalled,
+          readyIssue: i18n.global.t('dashboard.healthCheck.issues.psEventbusTablesMissing'),
           version: psEventbus.version,
           latestVersion: psEventbus.latestVersion,
           upToDate: psEventbus.upToDate,

--- a/frontend/js/stores/dashboard-store.js
+++ b/frontend/js/stores/dashboard-store.js
@@ -1,0 +1,346 @@
+import { defineStore } from 'pinia'
+import { useAppStore } from './app-store'
+
+/**
+ * Contents no third-party module asked for, so CloudSync never collects them.
+ * Mocked selection, for the sake of the example.
+ */
+const MOCK_NOT_REQUESTED = ['wishlists', 'wishlist_products', 'employees', 'translations', 'taxonomies', 'stock_movements']
+
+/**
+ * Contents whose last upload failed. Mocked selection, for the sake of the
+ * example.
+ */
+const MOCK_FAILED = {
+  images: { httpStatus: 504, httpStatusText: 'Gateway Timeout' },
+  stocks: { httpStatus: 500, httpStatusText: 'Internal Server Error' },
+  bundles: { httpStatus: 403, httpStatusText: 'Forbidden' },
+}
+
+/**
+ * Mock sync summary matching the Reporting API schema:
+ * GET /v1/reporting/shop-sync-summary/{shopId}
+ *
+ * Each item: { shopContent, requested, firstSyncFinishedAt, lastSyncFinishedAt,
+ * httpStatus, httpStatusText }. The HTTP status is the result of the last upload
+ * to the CloudSync cloud. `requested` is false when no third-party module
+ * subscribed to that content, in which case it is never synchronized at all.
+ *
+ * @see https://docs.cloudsync.prestashop.com/api-doc/reporting-api
+ */
+function getMockSyncSummary(shopContents) {
+  const now = Date.now()
+  const day = 86400000
+
+  return shopContents.map((shopContent, index) => {
+    if (MOCK_NOT_REQUESTED.includes(shopContent)) {
+      return {
+        shopContent,
+        requested: false,
+        firstSyncFinishedAt: null,
+        lastSyncFinishedAt: null,
+        httpStatus: null,
+        httpStatusText: null,
+      }
+    }
+
+    const failure = MOCK_FAILED[shopContent]
+
+    return {
+      shopContent,
+      requested: true,
+      firstSyncFinishedAt: failure ? null : new Date(now - day * 3).toISOString(),
+      lastSyncFinishedAt: new Date(now - 60000 * (index + 1)).toISOString(),
+      httpStatus: failure ? failure.httpStatus : 200,
+      httpStatusText: failure ? failure.httpStatusText : 'OK',
+    }
+  })
+}
+
+/**
+ * Mock of the shop URL CloudSync actually synchronizes with, compared against
+ * the one registered in PrestaShop Account to detect a mismatch. No endpoint
+ * serves it yet.
+ */
+function getMockCloudsyncStatus(accountsShopUrl) {
+  return {
+    // Mirrors the Account URL so the check reads "Match" until a real endpoint
+    // provides the URL CloudSync is actually configured with.
+    shopUrl: accountsShopUrl,
+  }
+}
+
+/**
+ * Mock of the round trip that asks CloudSync to call the shop's health check
+ * front controller from the outside and report back whether it got through.
+ *
+ * This has to be triggered from CloudSync rather than from the browser: only a
+ * request coming from CloudSync's own network can reveal that a WAF, a firewall
+ * or a Cloudflare challenge stands between the two. The endpoint does not exist
+ * yet, so the shape of the request and of the answer below is provisional.
+ */
+async function requestMockServerAccessCheck(healthCheckUrl) {
+  await new Promise((resolve) => setTimeout(resolve, 1200))
+
+  return {
+    // Echoed back so the UI can show which URL was probed
+    probedUrl: healthCheckUrl,
+    reachable: false,
+    httpStatus: 403,
+    blockedBy: 'Cloudflare',
+  }
+}
+
+/**
+ * A module row, resolved in order of severity: not installed at all, then not
+ * operational, then behind the latest release, then fine. `upToDate` is null
+ * when the latest version could not be determined, in which case no claim is
+ * made about it.
+ */
+function buildModuleCheck(id, { installed, ready, version, latestVersion, upToDate }) {
+  const detail = version ? `v${version}` : ''
+
+  if (!installed) {
+    return { id, status: 'error', badge: 'notInstalled', detail: '' }
+  }
+
+  if (!ready) {
+    return { id, status: 'error', badge: 'ko', detail }
+  }
+
+  if (upToDate === false) {
+    return { id, status: 'warning', badge: 'outdated', detail: `${detail} → v${latestVersion}` }
+  }
+
+  if (upToDate === null) {
+    return { id, status: 'ok', badge: 'ok', detail }
+  }
+
+  return { id, status: 'ok', badge: 'upToDate', detail }
+}
+
+const SERVER_ACCESS_STATUS = {
+  idle: 'idle',
+  running: 'idle',
+  reachable: 'ok',
+  blocked: 'warning',
+}
+
+function formatCompatibilityDetail(compatibility) {
+  const php = compatibility.phpCompatible ? `PHP ${compatibility.phpVersion}` : `PHP ${compatibility.phpVersion} < ${compatibility.minPhpVersion}`
+
+  const prestashop = compatibility.prestashopCompatible
+    ? `PrestaShop ${compatibility.prestashopVersion}`
+    : `PrestaShop ${compatibility.prestashopVersion} < ${compatibility.minPrestashopVersion}`
+
+  return `${php} · ${prestashop}`
+}
+
+export const useDashboardStore = defineStore('dashboard', {
+  state: () => ({
+    healthCheck: null,
+    syncSummary: [],
+    cloudsyncShopUrl: '',
+    // 'idle' until the merchant asks CloudSync to probe the shop, then
+    // 'running', then 'reachable' or 'blocked'
+    serverAccess: { status: 'idle', message: '' },
+    healthCheckLoading: false,
+    healthCheckError: null,
+    syncSummaryLoading: false,
+    syncSummaryError: null,
+  }),
+
+  getters: {
+    /**
+     * Contents actually collected. The ones no third-party module subscribed to
+     * are never synchronized by design, so counting them would hold the
+     * progress below 100% and the card in "syncing" state forever.
+     */
+    requestedSyncSummary() {
+      return this.syncSummary.filter((item) => item.requested !== false)
+    },
+
+    failedSyncSummary() {
+      return this.requestedSyncSummary.filter((item) => item.httpStatus && item.httpStatus >= 400)
+    },
+
+    globalSyncStatus() {
+      const requested = this.requestedSyncSummary
+
+      if (requested.length === 0) {
+        return 'offboarded'
+      }
+
+      if (this.failedSyncSummary.length > 0) return 'failed'
+
+      const allFinished = requested.every((item) => item.firstSyncFinishedAt)
+      const anyFinished = requested.some((item) => item.firstSyncFinishedAt)
+
+      if (allFinished) return 'synced'
+      if (anyFinished) return 'syncing'
+
+      return 'offboarded'
+    },
+
+    lastSyncedAt() {
+      const timestamps = this.requestedSyncSummary.filter((item) => item.lastSyncFinishedAt).map((item) => new Date(item.lastSyncFinishedAt).getTime())
+
+      return timestamps.length > 0 ? Math.max(...timestamps) : null
+    },
+
+    syncProgress() {
+      const requested = this.requestedSyncSummary
+
+      if (requested.length === 0) return 0
+
+      const completed = requested.filter((item) => item.firstSyncFinishedAt).length
+
+      return Math.round((completed / requested.length) * 100)
+    },
+
+    /**
+     * Checks displayed in the "Sync health check" card.
+     *
+     * Three of them are answered by the module itself (PHP ajax endpoint): the
+     * two module states and the PHP / PrestaShop compatibility.
+     *
+     * `urlMatching` compares the shop URL registered against the PrestaShop
+     * Account with the one CloudSync synchronizes with, so it needs both sides.
+     * `serverAccess` can only be answered from the outside, so it is run on
+     * demand: the merchant asks CloudSync to call the shop back. Both
+     * CloudSync-side values are still mocked.
+     */
+    healthChecks() {
+      if (!this.healthCheck) return []
+
+      const { psAccount, psEventbus, compatibility, accountsShopUrl } = this.healthCheck
+
+      const urlsMatch = !!accountsShopUrl && !!this.cloudsyncShopUrl && accountsShopUrl === this.cloudsyncShopUrl
+
+      return [
+        buildModuleCheck('psAccount', {
+          installed: psAccount.installed,
+          // ps_accounts is only useful once the shop is linked to an account
+          ready: psAccount.linked,
+          version: psAccount.version,
+          latestVersion: psAccount.latestVersion,
+          upToDate: psAccount.upToDate,
+        }),
+        buildModuleCheck('psEventbus', {
+          installed: true,
+          // Its own tables are what make the module operational
+          ready: psEventbus.tablesInstalled,
+          version: psEventbus.version,
+          latestVersion: psEventbus.latestVersion,
+          upToDate: psEventbus.upToDate,
+        }),
+        {
+          id: 'urlMatching',
+          status: urlsMatch ? 'ok' : 'warning',
+          badge: urlsMatch ? 'match' : 'mismatch',
+          detail: urlsMatch ? '' : `${accountsShopUrl || '—'} ≠ ${this.cloudsyncShopUrl || '—'}`,
+        },
+        {
+          id: 'phpCompatibility',
+          status: compatibility.compatible ? 'ok' : 'error',
+          badge: compatibility.compatible ? 'compatible' : 'ko',
+          detail: formatCompatibilityDetail(compatibility),
+        },
+        {
+          id: 'serverAccess',
+          status: SERVER_ACCESS_STATUS[this.serverAccess.status] ?? 'warning',
+          badge: this.serverAccess.status === 'idle' ? '' : this.serverAccess.status,
+          detail: this.serverAccess.message,
+          // Rendered as a button on the row: nothing is probed until asked
+          action: 'runServerAccessCheck',
+          actionLoading: this.serverAccess.status === 'running',
+        },
+      ]
+    },
+  },
+
+  actions: {
+    async fetchHealthCheck() {
+      const appStore = useAppStore()
+      this.healthCheckLoading = true
+      this.healthCheckError = null
+
+      try {
+        const url = appStore.eventbusAjaxPath + '&action=getHealthCheck&ajax=1'
+        const response = await fetch(url)
+        const body = await response.text()
+        let data
+
+        try {
+          data = JSON.parse(body)
+        } catch {
+          // A PHP notice, a redirect to the login page or a WAF page ends up here
+          throw new Error(`Unexpected response from the health check endpoint (HTTP ${response.status}): ${body.slice(0, 200)}`)
+        }
+
+        if (data.error) {
+          this.healthCheckError = data.message
+        } else {
+          this.healthCheck = data
+        }
+      } catch (e) {
+        this.healthCheckError = e.message
+      } finally {
+        this.healthCheckLoading = false
+      }
+    },
+
+    async fetchSyncSummary() {
+      const appStore = useAppStore()
+      this.syncSummaryLoading = true
+      this.syncSummaryError = null
+
+      try {
+        this.syncSummary = getMockSyncSummary(appStore.shopContents)
+      } catch (e) {
+        this.syncSummaryError = e.message
+      } finally {
+        this.syncSummaryLoading = false
+      }
+    },
+
+    async fetchCloudsyncStatus() {
+      const status = getMockCloudsyncStatus(this.healthCheck ? this.healthCheck.accountsShopUrl : '')
+
+      this.cloudsyncShopUrl = status.shopUrl
+    },
+
+    /**
+     * Asks CloudSync to call the shop's health check from its own network and
+     * report back. Triggered by the merchant, never on page load: it costs a
+     * round trip through CloudSync.
+     */
+    async runServerAccessCheck() {
+      const appStore = useAppStore()
+
+      if (this.serverAccess.status === 'running') return
+
+      this.serverAccess = { status: 'running', message: '' }
+
+      try {
+        const result = await requestMockServerAccessCheck(appStore.healthCheckUrl)
+
+        this.serverAccess = result.reachable
+          ? { status: 'reachable', message: result.probedUrl }
+          : {
+              status: 'blocked',
+              message: [result.blockedBy, result.httpStatus].filter(Boolean).join(' · HTTP '),
+            }
+      } catch (e) {
+        this.serverAccess = { status: 'blocked', message: e.message }
+      }
+    },
+
+    async loadDashboard() {
+      await Promise.all([this.fetchHealthCheck(), this.fetchSyncSummary()])
+
+      // Needs the Account URL from the health check to compare it against
+      await this.fetchCloudsyncStatus()
+    },
+  },
+})

--- a/frontend/js/stores/dashboard-store.js
+++ b/frontend/js/stores/dashboard-store.js
@@ -148,9 +148,11 @@ export const useDashboardStore = defineStore('dashboard', {
         }),
         {
           id: 'urlMatching',
-          status: urlsMatch ? 'ok' : 'warning',
-          badge: urlsMatch ? 'match' : 'mismatch',
-          detail: urlsMatch ? '' : `${accountsShopUrl || '—'} ≠ ${this.cloudsyncShopUrl || '—'}`,
+          status: !psAccount.linked ? 'idle' : urlsMatch ? 'ok' : 'warning',
+          badge: !psAccount.linked ? '' : urlsMatch ? 'match' : 'mismatch',
+          detail: !psAccount.linked
+            ? i18n.global.t('dashboard.healthCheck.issues.urlMatchingRequiresAccount')
+            : urlsMatch ? '' : `${accountsShopUrl || '—'} ≠ ${this.cloudsyncShopUrl || '—'}`,
         },
         {
           id: 'phpCompatibility',

--- a/frontend/js/stores/dashboard-store.js
+++ b/frontend/js/stores/dashboard-store.js
@@ -1,95 +1,6 @@
 import { defineStore } from 'pinia'
 import { useAppStore } from './app-store'
-
-/**
- * Contents no third-party module asked for, so CloudSync never collects them.
- * Mocked selection, for the sake of the example.
- */
-const MOCK_NOT_REQUESTED = ['wishlists', 'wishlist_products', 'employees', 'translations', 'taxonomies', 'stock_movements']
-
-/**
- * Contents whose last upload failed. Mocked selection, for the sake of the
- * example.
- */
-const MOCK_FAILED = {
-  images: { httpStatus: 504, httpStatusText: 'Gateway Timeout' },
-  stocks: { httpStatus: 500, httpStatusText: 'Internal Server Error' },
-  bundles: { httpStatus: 403, httpStatusText: 'Forbidden' },
-}
-
-/**
- * Mock sync summary matching the Reporting API schema:
- * GET /v1/reporting/shop-sync-summary/{shopId}
- *
- * Each item: { shopContent, requested, firstSyncFinishedAt, lastSyncFinishedAt,
- * httpStatus, httpStatusText }. The HTTP status is the result of the last upload
- * to the CloudSync cloud. `requested` is false when no third-party module
- * subscribed to that content, in which case it is never synchronized at all.
- *
- * @see https://docs.cloudsync.prestashop.com/api-doc/reporting-api
- */
-function getMockSyncSummary(shopContents) {
-  const now = Date.now()
-  const day = 86400000
-
-  return shopContents.map((shopContent, index) => {
-    if (MOCK_NOT_REQUESTED.includes(shopContent)) {
-      return {
-        shopContent,
-        requested: false,
-        firstSyncFinishedAt: null,
-        lastSyncFinishedAt: null,
-        httpStatus: null,
-        httpStatusText: null,
-      }
-    }
-
-    const failure = MOCK_FAILED[shopContent]
-
-    return {
-      shopContent,
-      requested: true,
-      firstSyncFinishedAt: failure ? null : new Date(now - day * 3).toISOString(),
-      lastSyncFinishedAt: new Date(now - 60000 * (index + 1)).toISOString(),
-      httpStatus: failure ? failure.httpStatus : 200,
-      httpStatusText: failure ? failure.httpStatusText : 'OK',
-    }
-  })
-}
-
-/**
- * Mock of the shop URL CloudSync actually synchronizes with, compared against
- * the one registered in PrestaShop Account to detect a mismatch. No endpoint
- * serves it yet.
- */
-function getMockCloudsyncStatus(accountsShopUrl) {
-  return {
-    // Mirrors the Account URL so the check reads "Match" until a real endpoint
-    // provides the URL CloudSync is actually configured with.
-    shopUrl: accountsShopUrl,
-  }
-}
-
-/**
- * Mock of the round trip that asks CloudSync to call the shop's health check
- * front controller from the outside and report back whether it got through.
- *
- * This has to be triggered from CloudSync rather than from the browser: only a
- * request coming from CloudSync's own network can reveal that a WAF, a firewall
- * or a Cloudflare challenge stands between the two. The endpoint does not exist
- * yet, so the shape of the request and of the answer below is provisional.
- */
-async function requestMockServerAccessCheck(healthCheckUrl) {
-  await new Promise((resolve) => setTimeout(resolve, 1200))
-
-  return {
-    // Echoed back so the UI can show which URL was probed
-    probedUrl: healthCheckUrl,
-    reachable: false,
-    httpStatus: 403,
-    blockedBy: 'Cloudflare',
-  }
-}
+import { fetchSyncSummary, fetchCloudsyncStatus, requestServerAccessCheck } from '../api/mock-interceptor'
 
 /**
  * A module row, resolved in order of severity: not installed at all, then not
@@ -113,7 +24,7 @@ function buildModuleCheck(id, { installed, ready, version, latestVersion, upToDa
   }
 
   if (upToDate === null) {
-    return { id, status: 'ok', badge: 'ok', detail }
+    return { id, status: 'ok', badge: 'installed', detail }
   }
 
   return { id, status: 'ok', badge: 'upToDate', detail }
@@ -296,7 +207,7 @@ export const useDashboardStore = defineStore('dashboard', {
       this.syncSummaryError = null
 
       try {
-        this.syncSummary = getMockSyncSummary(appStore.shopContents)
+        this.syncSummary = await fetchSyncSummary(appStore.cloudsyncApiUrl, appStore.shopId)
       } catch (e) {
         this.syncSummaryError = e.message
       } finally {
@@ -305,9 +216,19 @@ export const useDashboardStore = defineStore('dashboard', {
     },
 
     async fetchCloudsyncStatus() {
-      const status = getMockCloudsyncStatus(this.healthCheck ? this.healthCheck.accountsShopUrl : '')
+      const appStore = useAppStore()
 
-      this.cloudsyncShopUrl = status.shopUrl
+      try {
+        const status = await fetchCloudsyncStatus(
+          appStore.cloudsyncApiUrl,
+          appStore.shopId,
+          this.healthCheck ? this.healthCheck.accountsShopUrl : '',
+        )
+
+        this.cloudsyncShopUrl = status.shopUrl
+      } catch (e) {
+        this.cloudsyncShopUrl = ''
+      }
     },
 
     /**
@@ -323,7 +244,7 @@ export const useDashboardStore = defineStore('dashboard', {
       this.serverAccess = { status: 'running', message: '' }
 
       try {
-        const result = await requestMockServerAccessCheck(appStore.healthCheckUrl)
+        const result = await requestServerAccessCheck(appStore.cloudsyncApiUrl, appStore.shopId, appStore.healthCheckUrl)
 
         this.serverAccess = result.reachable
           ? { status: 'reachable', message: result.probedUrl }

--- a/frontend/js/stores/dashboard-store.js
+++ b/frontend/js/stores/dashboard-store.js
@@ -3,6 +3,20 @@ import i18n from '../i18n'
 import { useAppStore } from './app-store'
 import { fetchSyncSummary, fetchCloudsyncStatus, requestServerAccessCheck } from '../api/mock-interceptor'
 
+export const SYNC_STATUS = {
+  offboarded: 'offboarded',
+  syncing: 'syncing',
+  synced: 'synced',
+  failed: 'failed',
+}
+
+export const SERVER_ACCESS = {
+  idle: 'idle',
+  running: 'running',
+  reachable: 'reachable',
+  blocked: 'blocked',
+}
+
 /**
  * A module row, resolved in order of severity: not installed at all, then not
  * operational, then behind the latest release, then fine. `upToDate` is null
@@ -31,11 +45,11 @@ function buildModuleCheck(id, { installed, ready, readyIssue, version, latestVer
   return { id, status: 'ok', badge: 'upToDate', detail }
 }
 
-const SERVER_ACCESS_STATUS = {
-  idle: 'idle',
-  running: 'idle',
-  reachable: 'ok',
-  blocked: 'warning',
+const SERVER_ACCESS_STATUS_MAP = {
+  [SERVER_ACCESS.idle]: 'idle',
+  [SERVER_ACCESS.running]: 'idle',
+  [SERVER_ACCESS.reachable]: 'ok',
+  [SERVER_ACCESS.blocked]: 'warning',
 }
 
 function formatCompatibilityDetail(compatibility) {
@@ -80,18 +94,18 @@ export const useDashboardStore = defineStore('dashboard', {
       const requested = this.requestedSyncSummary
 
       if (requested.length === 0) {
-        return 'offboarded'
+        return SYNC_STATUS.offboarded
       }
 
-      if (this.failedSyncSummary.length > 0) return 'failed'
+      if (this.failedSyncSummary.length > 0) return SYNC_STATUS.failed
 
       const allFinished = requested.every((item) => item.firstSyncFinishedAt)
       const anyFinished = requested.some((item) => item.firstSyncFinishedAt)
 
-      if (allFinished) return 'synced'
-      if (anyFinished) return 'syncing'
+      if (allFinished) return SYNC_STATUS.synced
+      if (anyFinished) return SYNC_STATUS.syncing
 
-      return 'offboarded'
+      return SYNC_STATUS.offboarded
     },
 
     lastSyncedAt() {
@@ -162,8 +176,8 @@ export const useDashboardStore = defineStore('dashboard', {
         },
         {
           id: 'serverAccess',
-          status: SERVER_ACCESS_STATUS[this.serverAccess.status] ?? 'warning',
-          badge: this.serverAccess.status === 'idle' ? '' : this.serverAccess.status,
+          status: SERVER_ACCESS_STATUS_MAP[this.serverAccess.status] ?? 'warning',
+          badge: this.serverAccess.status === SERVER_ACCESS.idle ? '' : this.serverAccess.status,
           detail: this.serverAccess.message,
           // Rendered as a button on the row: nothing is probed until asked
           action: 'runServerAccessCheck',
@@ -222,11 +236,7 @@ export const useDashboardStore = defineStore('dashboard', {
       const appStore = useAppStore()
 
       try {
-        const status = await fetchCloudsyncStatus(
-          appStore.cloudsyncApiUrl,
-          appStore.shopId,
-          this.healthCheck ? this.healthCheck.accountsShopUrl : '',
-        )
+        const status = await fetchCloudsyncStatus(appStore.cloudsyncApiUrl, appStore.shopId)
 
         this.cloudsyncShopUrl = status.shopUrl
       } catch (e) {
@@ -242,21 +252,21 @@ export const useDashboardStore = defineStore('dashboard', {
     async runServerAccessCheck() {
       const appStore = useAppStore()
 
-      if (this.serverAccess.status === 'running') return
+      if (this.serverAccess.status === SERVER_ACCESS.running) return
 
-      this.serverAccess = { status: 'running', message: '' }
+      this.serverAccess = { status: SERVER_ACCESS.running, message: '' }
 
       try {
         const result = await requestServerAccessCheck(appStore.cloudsyncApiUrl, appStore.shopId, appStore.healthCheckUrl)
 
         this.serverAccess = result.reachable
-          ? { status: 'reachable', message: result.probedUrl }
+          ? { status: SERVER_ACCESS.reachable, message: result.probedUrl }
           : {
-              status: 'blocked',
+              status: SERVER_ACCESS.blocked,
               message: [result.blockedBy, result.httpStatus].filter(Boolean).join(' · HTTP '),
             }
       } catch (e) {
-        this.serverAccess = { status: 'blocked', message: e.message }
+        this.serverAccess = { status: SERVER_ACCESS.blocked, message: e.message }
       }
     },
 

--- a/frontend/scss/global.scss
+++ b/frontend/scss/global.scss
@@ -4,6 +4,48 @@ $background-secondary: #f7f7f7;
 $text-primary: black;
 $text-secondary: #5e5e5e;
 
+// Dashboard layout tokens
+$page-background: #fafafa;
+$card-background: #ffffff;
+$card-border: #e7e7e7;
+$card-radius: 8px;
+$card-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+$row-border: #ededed;
+
+$status-ok: #2fa84f;
+$status-warning: #f5a623;
+$status-error: #e4553a;
+
+$accent-soft: #cfeef5;
+$accent: #1c9ab5;
+
+$content-max-width: 860px;
+
+@mixin dashboard-card {
+  padding: 20px 24px;
+  margin-bottom: 24px;
+  background-color: $card-background;
+  border: 1px solid $card-border;
+  border-radius: $card-radius;
+  box-shadow: $card-shadow;
+}
+
+@mixin dashboard-card-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: $text-primary;
+}
+
 label {
   margin-bottom: 0px;
+}
+
+.puik-tag__content {
+  p {
+    margin: 0;
+  }
 }

--- a/frontend/scss/global.scss
+++ b/frontend/scss/global.scss
@@ -49,3 +49,16 @@ label {
     margin: 0;
   }
 }
+
+.puik-tab-navigation__title {
+  border-bottom: 0;
+}
+
+.adminpseventbus #content.bootstrap {
+  padding-right: 0;
+  padding-left: var(--cdk-sidebar-width);
+}
+
+.adminpseventbus.page-sidebar-closed #content.bootstrap {
+  padding-left: 52px;
+}

--- a/frontend/scss/global.scss
+++ b/frontend/scss/global.scss
@@ -20,6 +20,7 @@ $accent-soft: #cfeef5;
 $accent: #1c9ab5;
 
 $content-max-width: 860px;
+$row-gap: 12px;
 
 @mixin dashboard-card {
   padding: 20px 24px;

--- a/frontend/scss/global.scss
+++ b/frontend/scss/global.scss
@@ -56,6 +56,7 @@ label {
 
 .adminpseventbus #content.bootstrap {
   padding-right: 0;
+  padding-top: 0;
   padding-left: var(--cdk-sidebar-width);
 }
 

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -69,6 +69,10 @@
         "blocked": "Blocked",
         "installed": "Installed"
       },
+      "issues": {
+        "psAccountNotLinked": "Shop is not linked to a PrestaShop Account",
+        "psEventbusTablesMissing": "Required database tables are missing — try reinstalling the module"
+      },
       "checks": {
         "psAccount": {
           "label": "PS Account module"

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -1,11 +1,11 @@
 {
   "header": {
-    "title": "PrestaShop EventBus"
+    "title": "PS EventBus"
   },
   "tabs": {
     "dashboard": "Dashboard",
     "connections": "Connections",
-    "supportDebug": "Support & Debug"
+    "supportDebug": "Support & debug"
   },
   "pages": {
     "dashboard": {
@@ -15,7 +15,85 @@
       "title": "Connections"
     },
     "supportDebug": {
-      "title": "Support & Debug"
+      "title": "Support & debug"
+    }
+  },
+  "dashboard": {
+    "syncStatus": {
+      "synced": "Synced",
+      "syncing": "Syncing",
+      "failed": "Failed",
+      "offboarded": "Not configured",
+      "pending": "Pending",
+      "lastSynced": "Last synced"
+    },
+    "timeAgo": {
+      "justNow": "Just now",
+      "minutesAgo": "{n} min ago",
+      "hoursAgo": "{n}h ago",
+      "daysAgo": "{n}d ago"
+    },
+    "syncCard": {
+      "initial": {
+        "title": "Initial synchronization in progress",
+        "description": "CloudSync is importing your catalog and order data for the first time. This may take a few minutes depending on your store size."
+      },
+      "incremental": {
+        "title": "Synchronization up to date",
+        "description": "CloudSync is streaming your shop changes continuously.",
+        "descriptionWithTime": "CloudSync is streaming your shop changes continuously. Last update {time}."
+      },
+      "failed": {
+        "title": "Synchronization failed",
+        "description": "Some shop content could not be sent to CloudSync. Check the health check below for details."
+      },
+      "offboarded": {
+        "title": "Synchronization not started",
+        "description": "Link your PrestaShop Account and connect a service to start synchronizing your shop data."
+      }
+    },
+    "healthCheck": {
+      "title": "Sync health check",
+      "badges": {
+        "ok": "OK",
+        "ko": "KO",
+        "notInstalled": "Not installed",
+        "upToDate": "Up to date",
+        "outdated": "Update available",
+        "match": "Match",
+        "mismatch": "Mismatch",
+        "compatible": "Compatible",
+        "check": "Check",
+        "running": "Checking…",
+        "reachable": "Reachable",
+        "blocked": "Blocked"
+      },
+      "checks": {
+        "psAccount": {
+          "label": "PS Account module"
+        },
+        "psEventbus": {
+          "label": "PS EventBus module"
+        },
+        "urlMatching": {
+          "label": "URL matching",
+          "hint": "between Account and PS EventBus"
+        },
+        "phpCompatibility": {
+          "label": "PHP & PrestaShop compatibility"
+        },
+        "serverAccess": {
+          "label": "Server access check",
+          "hint": "asks CloudSync to call your shop back",
+          "action": "Run check"
+        }
+      }
+    },
+    "syncTable": {
+      "title": "Shop contents sync status",
+      "subtitle": "Status of each content type being synchronized to the CloudSync cloud",
+      "empty": "No synchronization data available yet.",
+      "notRequested": "Not requested"
     }
   }
 }

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -71,7 +71,8 @@
       },
       "issues": {
         "psAccountNotLinked": "Shop is not linked to a PrestaShop Account",
-        "psEventbusTablesMissing": "Required database tables are missing — try reinstalling the module"
+        "psEventbusTablesMissing": "Required database tables are missing — try reinstalling the module",
+        "urlMatchingRequiresAccount": "Requires PS Account to be installed and linked"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -66,7 +66,8 @@
         "check": "Check",
         "running": "Checking…",
         "reachable": "Reachable",
-        "blocked": "Blocked"
+        "blocked": "Blocked",
+        "installed": "Installed"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/es.json
+++ b/frontend/translations/es.json
@@ -66,7 +66,8 @@
         "check": "Revisar",
         "running": "Comprobando…",
         "reachable": "Accesible",
-        "blocked": "Bloqueado"
+        "blocked": "Bloqueado",
+        "installed": "Instalado"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/es.json
+++ b/frontend/translations/es.json
@@ -71,7 +71,8 @@
       },
       "issues": {
         "psAccountNotLinked": "La tienda no está vinculada a una cuenta PrestaShop",
-        "psEventbusTablesMissing": "Faltan las tablas necesarias — intente reinstalar el módulo"
+        "psEventbusTablesMissing": "Faltan las tablas necesarias — intente reinstalar el módulo",
+        "urlMatchingRequiresAccount": "Requiere que PS Account esté instalado y vinculado"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/es.json
+++ b/frontend/translations/es.json
@@ -1,0 +1,99 @@
+{
+  "header": {
+    "title": "PS EventBus"
+  },
+  "tabs": {
+    "dashboard": "Panel de control",
+    "connections": "Conexiones",
+    "supportDebug": "Soporte y depuración"
+  },
+  "pages": {
+    "dashboard": {
+      "title": "Panel de control"
+    },
+    "connections": {
+      "title": "Conexiones"
+    },
+    "supportDebug": {
+      "title": "Soporte y depuración"
+    }
+  },
+  "dashboard": {
+    "syncStatus": {
+      "synced": "Sincronizado",
+      "syncing": "Sincronizando",
+      "failed": "Fallido",
+      "offboarded": "No configurado",
+      "pending": "Pendiente",
+      "lastSynced": "Última sincronización"
+    },
+    "timeAgo": {
+      "justNow": "Ahora mismo",
+      "minutesAgo": "Hace {n} min",
+      "hoursAgo": "Hace {n}h",
+      "daysAgo": "Hace {n}d"
+    },
+    "syncCard": {
+      "initial": {
+        "title": "Sincronización inicial en curso",
+        "description": "CloudSync está importando por primera vez los datos de tu catálogo y tus pedidos. Esto puede tardar unos minutos según el tamaño de tu tienda."
+      },
+      "incremental": {
+        "title": "Sincronización al día",
+        "description": "CloudSync transmite continuamente los cambios de tu tienda.",
+        "descriptionWithTime": "CloudSync transmite continuamente los cambios de tu tienda. Última actualización {time}."
+      },
+      "failed": {
+        "title": "Error de sincronización",
+        "description": "Algunos contenidos de la tienda no se pudieron enviar a CloudSync. Consulta la verificación de estado a continuación."
+      },
+      "offboarded": {
+        "title": "Sincronización no iniciada",
+        "description": "Vincula tu cuenta PrestaShop y conecta un servicio para empezar a sincronizar tu tienda."
+      }
+    },
+    "healthCheck": {
+      "title": "Verificación de la sincronización",
+      "badges": {
+        "ok": "OK",
+        "ko": "KO",
+        "notInstalled": "No instalado",
+        "upToDate": "Actualizado",
+        "outdated": "Actualización disponible",
+        "match": "Coincide",
+        "mismatch": "No coincide",
+        "compatible": "Compatible",
+        "check": "Revisar",
+        "running": "Comprobando…",
+        "reachable": "Accesible",
+        "blocked": "Bloqueado"
+      },
+      "checks": {
+        "psAccount": {
+          "label": "Módulo PS Account"
+        },
+        "psEventbus": {
+          "label": "Módulo PS EventBus"
+        },
+        "urlMatching": {
+          "label": "Coincidencia de URL",
+          "hint": "entre Account y PS EventBus"
+        },
+        "phpCompatibility": {
+          "label": "Compatibilidad PHP y PrestaShop"
+        },
+        "serverAccess": {
+          "label": "Verificación de acceso al servidor",
+          "hint": "pide a CloudSync que contacte tu tienda",
+          "action": "Ejecutar prueba"
+        }
+      }
+    },
+    "syncTable": {
+      "title": "Estado de sincronización de los contenidos",
+      "subtitle": "Estado de cada tipo de contenido sincronizado con la nube de CloudSync",
+      "empty": "No hay datos de sincronización disponibles aún.",
+      "notRequested": "No solicitado"
+    }
+  }
+}

--- a/frontend/translations/es.json
+++ b/frontend/translations/es.json
@@ -69,6 +69,10 @@
         "blocked": "Bloqueado",
         "installed": "Instalado"
       },
+      "issues": {
+        "psAccountNotLinked": "La tienda no está vinculada a una cuenta PrestaShop",
+        "psEventbusTablesMissing": "Faltan las tablas necesarias — intente reinstalar el módulo"
+      },
       "checks": {
         "psAccount": {
           "label": "Módulo PS Account"

--- a/frontend/translations/fr.json
+++ b/frontend/translations/fr.json
@@ -1,11 +1,11 @@
 {
   "header": {
-    "title": "PrestaShop EventBus"
+    "title": "PS EventBus"
   },
   "tabs": {
     "dashboard": "Tableau de bord",
     "connections": "Connexions",
-    "supportDebug": "Support & Débogage"
+    "supportDebug": "Support & débogage"
   },
   "pages": {
     "dashboard": {
@@ -15,7 +15,85 @@
       "title": "Connexions"
     },
     "supportDebug": {
-      "title": "Support & Débogage"
+      "title": "Support & débogage"
+    }
+  },
+  "dashboard": {
+    "syncStatus": {
+      "synced": "Synchronisé",
+      "syncing": "Synchronisation",
+      "failed": "Échoué",
+      "offboarded": "Non configuré",
+      "pending": "En attente",
+      "lastSynced": "Dernière synchronisation"
+    },
+    "timeAgo": {
+      "justNow": "À l'instant",
+      "minutesAgo": "Il y a {n} min",
+      "hoursAgo": "Il y a {n}h",
+      "daysAgo": "Il y a {n}j"
+    },
+    "syncCard": {
+      "initial": {
+        "title": "Synchronisation initiale en cours",
+        "description": "CloudSync importe pour la première fois les données de votre catalogue et de vos commandes. Cela peut prendre quelques minutes selon la taille de votre boutique."
+      },
+      "incremental": {
+        "title": "Synchronisation à jour",
+        "description": "CloudSync transmet en continu les modifications de votre boutique.",
+        "descriptionWithTime": "CloudSync transmet en continu les modifications de votre boutique. Dernière mise à jour {time}."
+      },
+      "failed": {
+        "title": "Échec de la synchronisation",
+        "description": "Certains contenus de la boutique n'ont pas pu être envoyés à CloudSync. Consultez la vérification de santé ci-dessous."
+      },
+      "offboarded": {
+        "title": "Synchronisation non démarrée",
+        "description": "Liez votre compte PrestaShop et connectez un service pour lancer la synchronisation de votre boutique."
+      }
+    },
+    "healthCheck": {
+      "title": "Vérification de la synchronisation",
+      "badges": {
+        "ok": "OK",
+        "ko": "KO",
+        "notInstalled": "Non installé",
+        "upToDate": "À jour",
+        "outdated": "Mise à jour disponible",
+        "match": "Correspond",
+        "mismatch": "Ne correspond pas",
+        "compatible": "Compatible",
+        "check": "À vérifier",
+        "running": "Vérification…",
+        "reachable": "Joignable",
+        "blocked": "Bloqué"
+      },
+      "checks": {
+        "psAccount": {
+          "label": "Module PS Account"
+        },
+        "psEventbus": {
+          "label": "Module PS EventBus"
+        },
+        "urlMatching": {
+          "label": "Correspondance des URL",
+          "hint": "entre Account et PS EventBus"
+        },
+        "phpCompatibility": {
+          "label": "Compatibilité PHP & PrestaShop"
+        },
+        "serverAccess": {
+          "label": "Vérification de l'accès au serveur",
+          "hint": "demande à CloudSync de rappeler votre boutique",
+          "action": "Lancer le test"
+        }
+      }
+    },
+    "syncTable": {
+      "title": "Statut de synchronisation des contenus",
+      "subtitle": "Statut de chaque type de contenu synchronisé vers le cloud CloudSync",
+      "empty": "Aucune donnée de synchronisation disponible pour le moment.",
+      "notRequested": "Non demandé"
     }
   }
 }

--- a/frontend/translations/fr.json
+++ b/frontend/translations/fr.json
@@ -66,7 +66,8 @@
         "check": "À vérifier",
         "running": "Vérification…",
         "reachable": "Joignable",
-        "blocked": "Bloqué"
+        "blocked": "Bloqué",
+        "installed": "Installé"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/fr.json
+++ b/frontend/translations/fr.json
@@ -69,6 +69,10 @@
         "blocked": "Bloqué",
         "installed": "Installé"
       },
+      "issues": {
+        "psAccountNotLinked": "La boutique n'est pas liée à un compte PrestaShop",
+        "psEventbusTablesMissing": "Les tables requises sont manquantes — essayez de réinstaller le module"
+      },
       "checks": {
         "psAccount": {
           "label": "Module PS Account"

--- a/frontend/translations/fr.json
+++ b/frontend/translations/fr.json
@@ -71,7 +71,8 @@
       },
       "issues": {
         "psAccountNotLinked": "La boutique n'est pas liée à un compte PrestaShop",
-        "psEventbusTablesMissing": "Les tables requises sont manquantes — essayez de réinstaller le module"
+        "psEventbusTablesMissing": "Les tables requises sont manquantes — essayez de réinstaller le module",
+        "urlMatchingRequiresAccount": "Nécessite que PS Account soit installé et lié"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/it.json
+++ b/frontend/translations/it.json
@@ -71,7 +71,8 @@
       },
       "issues": {
         "psAccountNotLinked": "Il negozio non è collegato a un account PrestaShop",
-        "psEventbusTablesMissing": "Le tabelle richieste mancano — provare a reinstallare il modulo"
+        "psEventbusTablesMissing": "Le tabelle richieste mancano — provare a reinstallare il modulo",
+        "urlMatchingRequiresAccount": "Richiede che PS Account sia installato e collegato"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/it.json
+++ b/frontend/translations/it.json
@@ -69,6 +69,10 @@
         "blocked": "Bloccato",
         "installed": "Installato"
       },
+      "issues": {
+        "psAccountNotLinked": "Il negozio non è collegato a un account PrestaShop",
+        "psEventbusTablesMissing": "Le tabelle richieste mancano — provare a reinstallare il modulo"
+      },
       "checks": {
         "psAccount": {
           "label": "Modulo PS Account"

--- a/frontend/translations/it.json
+++ b/frontend/translations/it.json
@@ -66,7 +66,8 @@
         "check": "Da verificare",
         "running": "Verifica in corso…",
         "reachable": "Raggiungibile",
-        "blocked": "Bloccato"
+        "blocked": "Bloccato",
+        "installed": "Installato"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/it.json
+++ b/frontend/translations/it.json
@@ -1,0 +1,99 @@
+{
+  "header": {
+    "title": "PS EventBus"
+  },
+  "tabs": {
+    "dashboard": "Pannello di controllo",
+    "connections": "Connessioni",
+    "supportDebug": "Supporto e debug"
+  },
+  "pages": {
+    "dashboard": {
+      "title": "Pannello di controllo"
+    },
+    "connections": {
+      "title": "Connessioni"
+    },
+    "supportDebug": {
+      "title": "Supporto e debug"
+    }
+  },
+  "dashboard": {
+    "syncStatus": {
+      "synced": "Sincronizzato",
+      "syncing": "Sincronizzazione",
+      "failed": "Fallito",
+      "offboarded": "Non configurato",
+      "pending": "In attesa",
+      "lastSynced": "Ultima sincronizzazione"
+    },
+    "timeAgo": {
+      "justNow": "Adesso",
+      "minutesAgo": "{n} min fa",
+      "hoursAgo": "{n}h fa",
+      "daysAgo": "{n}g fa"
+    },
+    "syncCard": {
+      "initial": {
+        "title": "Sincronizzazione iniziale in corso",
+        "description": "CloudSync sta importando per la prima volta i dati del tuo catalogo e dei tuoi ordini. Potrebbe richiedere qualche minuto a seconda della dimensione del negozio."
+      },
+      "incremental": {
+        "title": "Sincronizzazione aggiornata",
+        "description": "CloudSync trasmette in continuo le modifiche del tuo negozio.",
+        "descriptionWithTime": "CloudSync trasmette in continuo le modifiche del tuo negozio. Ultimo aggiornamento {time}."
+      },
+      "failed": {
+        "title": "Sincronizzazione non riuscita",
+        "description": "Alcuni contenuti del negozio non sono stati inviati a CloudSync. Consulta il controllo dello stato qui sotto."
+      },
+      "offboarded": {
+        "title": "Sincronizzazione non avviata",
+        "description": "Collega il tuo account PrestaShop e connetti un servizio per avviare la sincronizzazione del negozio."
+      }
+    },
+    "healthCheck": {
+      "title": "Controllo della sincronizzazione",
+      "badges": {
+        "ok": "OK",
+        "ko": "KO",
+        "notInstalled": "Non installato",
+        "upToDate": "Aggiornato",
+        "outdated": "Aggiornamento disponibile",
+        "match": "Corrisponde",
+        "mismatch": "Non corrisponde",
+        "compatible": "Compatibile",
+        "check": "Da verificare",
+        "running": "Verifica in corso…",
+        "reachable": "Raggiungibile",
+        "blocked": "Bloccato"
+      },
+      "checks": {
+        "psAccount": {
+          "label": "Modulo PS Account"
+        },
+        "psEventbus": {
+          "label": "Modulo PS EventBus"
+        },
+        "urlMatching": {
+          "label": "Corrispondenza degli URL",
+          "hint": "tra Account e PS EventBus"
+        },
+        "phpCompatibility": {
+          "label": "Compatibilità PHP e PrestaShop"
+        },
+        "serverAccess": {
+          "label": "Controllo dell'accesso al server",
+          "hint": "chiede a CloudSync di richiamare il tuo negozio",
+          "action": "Avvia il test"
+        }
+      }
+    },
+    "syncTable": {
+      "title": "Stato di sincronizzazione dei contenuti",
+      "subtitle": "Stato di ogni tipo di contenuto sincronizzato con il cloud CloudSync",
+      "empty": "Nessun dato di sincronizzazione disponibile al momento.",
+      "notRequested": "Non richiesto"
+    }
+  }
+}

--- a/frontend/translations/pl.json
+++ b/frontend/translations/pl.json
@@ -69,6 +69,10 @@
         "blocked": "Zablokowany",
         "installed": "Zainstalowany"
       },
+      "issues": {
+        "psAccountNotLinked": "Sklep nie jest powiązany z kontem PrestaShop",
+        "psEventbusTablesMissing": "Brakuje wymaganych tabel — spróbuj ponownie zainstalować moduł"
+      },
       "checks": {
         "psAccount": {
           "label": "Moduł PS Account"

--- a/frontend/translations/pl.json
+++ b/frontend/translations/pl.json
@@ -66,7 +66,8 @@
         "check": "Do sprawdzenia",
         "running": "Sprawdzanie…",
         "reachable": "Dostępny",
-        "blocked": "Zablokowany"
+        "blocked": "Zablokowany",
+        "installed": "Zainstalowany"
       },
       "checks": {
         "psAccount": {

--- a/frontend/translations/pl.json
+++ b/frontend/translations/pl.json
@@ -1,0 +1,99 @@
+{
+  "header": {
+    "title": "PS EventBus"
+  },
+  "tabs": {
+    "dashboard": "Panel",
+    "connections": "Połączenia",
+    "supportDebug": "Wsparcie i debugowanie"
+  },
+  "pages": {
+    "dashboard": {
+      "title": "Panel"
+    },
+    "connections": {
+      "title": "Połączenia"
+    },
+    "supportDebug": {
+      "title": "Wsparcie i debugowanie"
+    }
+  },
+  "dashboard": {
+    "syncStatus": {
+      "synced": "Zsynchronizowany",
+      "syncing": "Synchronizacja",
+      "failed": "Niepowodzenie",
+      "offboarded": "Nieskonfigurowany",
+      "pending": "Oczekuje",
+      "lastSynced": "Ostatnia synchronizacja"
+    },
+    "timeAgo": {
+      "justNow": "Właśnie teraz",
+      "minutesAgo": "{n} min temu",
+      "hoursAgo": "{n} godz. temu",
+      "daysAgo": "{n} dni temu"
+    },
+    "syncCard": {
+      "initial": {
+        "title": "Trwa początkowa synchronizacja",
+        "description": "CloudSync importuje po raz pierwszy dane Twojego katalogu i zamówień. Może to potrwać kilka minut w zależności od rozmiaru sklepu."
+      },
+      "incremental": {
+        "title": "Synchronizacja jest aktualna",
+        "description": "CloudSync przesyła zmiany w Twoim sklepie na bieżąco.",
+        "descriptionWithTime": "CloudSync przesyła zmiany w Twoim sklepie na bieżąco. Ostatnia aktualizacja {time}."
+      },
+      "failed": {
+        "title": "Synchronizacja nie powiodła się",
+        "description": "Część zawartości sklepu nie została wysłana do CloudSync. Sprawdź kontrolę stanu poniżej."
+      },
+      "offboarded": {
+        "title": "Synchronizacja nie została rozpoczęta",
+        "description": "Połącz swoje konto PrestaShop i podłącz usługę, aby rozpocząć synchronizację sklepu."
+      }
+    },
+    "healthCheck": {
+      "title": "Kontrola synchronizacji",
+      "badges": {
+        "ok": "OK",
+        "ko": "KO",
+        "notInstalled": "Nie zainstalowano",
+        "upToDate": "Aktualny",
+        "outdated": "Dostępna aktualizacja",
+        "match": "Zgodne",
+        "mismatch": "Niezgodne",
+        "compatible": "Kompatybilne",
+        "check": "Do sprawdzenia",
+        "running": "Sprawdzanie…",
+        "reachable": "Dostępny",
+        "blocked": "Zablokowany"
+      },
+      "checks": {
+        "psAccount": {
+          "label": "Moduł PS Account"
+        },
+        "psEventbus": {
+          "label": "Moduł PS EventBus"
+        },
+        "urlMatching": {
+          "label": "Zgodność adresów URL",
+          "hint": "między Account i PS EventBus"
+        },
+        "phpCompatibility": {
+          "label": "Kompatybilność PHP i PrestaShop"
+        },
+        "serverAccess": {
+          "label": "Kontrola dostępu do serwera",
+          "hint": "prosi CloudSync o połączenie z Twoim sklepem",
+          "action": "Uruchom test"
+        }
+      }
+    },
+    "syncTable": {
+      "title": "Status synchronizacji zawartości sklepu",
+      "subtitle": "Status każdego typu zawartości synchronizowanego z chmurą CloudSync",
+      "empty": "Brak dostępnych danych synchronizacji.",
+      "notRequested": "Nie zamówiono"
+    }
+  }
+}

--- a/frontend/translations/pl.json
+++ b/frontend/translations/pl.json
@@ -71,7 +71,8 @@
       },
       "issues": {
         "psAccountNotLinked": "Sklep nie jest powiązany z kontem PrestaShop",
-        "psEventbusTablesMissing": "Brakuje wymaganych tabel — spróbuj ponownie zainstalować moduł"
+        "psEventbusTablesMissing": "Brakuje wymaganych tabel — spróbuj ponownie zainstalować moduł",
+        "urlMatchingRequiresAccount": "Wymaga zainstalowanego i powiązanego modułu PS Account"
       },
       "checks": {
         "psAccount": {

--- a/src/Service/ApiHealthCheckService.php
+++ b/src/Service/ApiHealthCheckService.php
@@ -297,12 +297,8 @@ class ApiHealthCheckService
                 return $unknown;
             }
 
+            /** @var \PrestaShop\PrestaShop\Core\Module\ModuleRepository $repo */
             $repo = $container->get('PrestaShop\PrestaShop\Core\Module\ModuleRepository');
-
-            if ($repo === null) {
-                return $unknown;
-            }
-
             $module = $repo->getModule($moduleName);
 
             $latestVersion = $module->attributes->get('version_available');

--- a/src/Service/ApiHealthCheckService.php
+++ b/src/Service/ApiHealthCheckService.php
@@ -300,6 +300,10 @@ class ApiHealthCheckService
             // @phpstan-ignore-next-line — getModule() exists at runtime; class unknown on PS 1.6/1.7
             $module = $container->get('PrestaShop\PrestaShop\Core\Module\ModuleRepository')->getModule($moduleName);
 
+            if ($module === null) {
+                return $unknown;
+            }
+
             $latestVersion = $module->attributes->get('version_available');
 
             if (empty($latestVersion)) {

--- a/src/Service/ApiHealthCheckService.php
+++ b/src/Service/ApiHealthCheckService.php
@@ -62,6 +62,17 @@ class ApiHealthCheckService
     ];
 
     /**
+     * Fallback lower bound, used only when ps_versions_compliancy cannot be
+     * read off the module instance.
+     */
+    const MIN_PRESTASHOP_VERSION = '1.6.1.11';
+
+    /**
+     * Mirrors ps_eventbus::isPhpVersionCompliant(), which gates the autoloader.
+     */
+    const MIN_PHP_VERSION = '5.6.0';
+
+    /**
      * @param PsAccountsAdapterService $psAccountsAdapterService
      * @param ErrorHandler $errorHandler
      * @param string $eventbusSyncApiUrl
@@ -158,6 +169,155 @@ class ApiHealthCheckService
         }
 
         return $serverInformation;
+    }
+
+    /**
+     * Health check for the module configuration page.
+     *
+     * Unlike getHealthCheck(), this is not the contract CloudSync probes: there
+     * is no job authorization involved, and it exposes what the dashboard needs
+     * to render its checks. Everything here is observable from inside the shop.
+     * The checks that require an outside view (does CloudSync reach us at all,
+     * is a WAF in the way) cannot be answered here.
+     *
+     * @return array<mixed>
+     *
+     * @throws \PrestaShopDatabaseException
+     */
+    public function getDashboardHealthCheck()
+    {
+        $psAccountsModule = $this->psAccountsAdapterService->getModule();
+        $psEventbusModule = \Module::getInstanceByName('ps_eventbus');
+
+        $tokenIsSet = false;
+
+        try {
+            $tokenIsSet = (bool) $this->psAccountsAdapterService->getShopToken();
+        } catch (\Exception $exception) {
+            $this->errorHandler->handle($exception);
+        }
+
+        $psAccountsUpdate = $this->getModuleUpdateState('ps_accounts', $psAccountsModule ? $psAccountsModule->version : null);
+        $psEventbusUpdate = $this->getModuleUpdateState('ps_eventbus', $psEventbusModule ? $psEventbusModule->version : null);
+
+        return [
+            'psAccount' => [
+                'installed' => (bool) $psAccountsModule,
+                'linked' => $tokenIsSet,
+                'version' => $psAccountsModule ? $psAccountsModule->version : null,
+                'latestVersion' => $psAccountsUpdate['latestVersion'],
+                'upToDate' => $psAccountsUpdate['upToDate'],
+            ],
+            'psEventbus' => [
+                'tablesInstalled' => count($this->getMissingRequiredTables()) === 0,
+                'version' => $psEventbusModule ? $psEventbusModule->version : null,
+                'latestVersion' => $psEventbusUpdate['latestVersion'],
+                'upToDate' => $psEventbusUpdate['upToDate'],
+            ],
+            'compatibility' => $this->getCompatibility($psEventbusModule),
+            'accountsShopUrl' => $this->psAccountsAdapterService->getShopUrl(),
+        ];
+    }
+
+    /**
+     * PHP and PrestaShop versions checked against what ps_eventbus declares it
+     * supports, rather than against hardcoded values.
+     *
+     * @param \ModuleCore|false $psEventbusModule
+     *
+     * @return array<mixed>
+     */
+    private function getCompatibility($psEventbusModule)
+    {
+        $minPrestashopVersion = self::MIN_PRESTASHOP_VERSION;
+
+        if ($psEventbusModule && !empty($psEventbusModule->ps_versions_compliancy['min'])) {
+            $minPrestashopVersion = (string) $psEventbusModule->ps_versions_compliancy['min'];
+        }
+
+        $phpVersion = $this->getPhpVersion();
+        $phpCompatible = version_compare($phpVersion, self::MIN_PHP_VERSION, '>=');
+        $prestashopCompatible = version_compare(_PS_VERSION_, $minPrestashopVersion, '>=');
+
+        return [
+            'phpVersion' => $phpVersion,
+            'minPhpVersion' => self::MIN_PHP_VERSION,
+            'phpCompatible' => $phpCompatible,
+            'prestashopVersion' => _PS_VERSION_,
+            'minPrestashopVersion' => $minPrestashopVersion,
+            'prestashopCompatible' => $prestashopCompatible,
+            'compatible' => $phpCompatible && $prestashopCompatible,
+        ];
+    }
+
+    /**
+     * The PHP version without its distribution suffix (ex: 8.1.2 instead of
+     * 8.1.2-1ubuntu2.14).
+     *
+     * @return string
+     */
+    private function getPhpVersion()
+    {
+        if (defined('PHP_VERSION') && defined('PHP_EXTRA_VERSION') && PHP_EXTRA_VERSION !== '') {
+            return str_replace(PHP_EXTRA_VERSION, '', PHP_VERSION);
+        }
+
+        return (string) explode('-', (string) phpversion())[0];
+    }
+
+    /**
+     * Whether a module is behind its latest published version.
+     *
+     * Delegated to the core module repository rather than queried ourselves, so
+     * that the dashboard reports exactly what the merchant already sees in the
+     * Module Manager, over whichever distribution channel the shop uses, with
+     * no extra HTTP call of our own.
+     *
+     * The repository only exists from PrestaShop 1.7 on and needs a booted
+     * Symfony container, so every failure mode degrades to "unknown" rather
+     * than to a false claim that the module is current.
+     *
+     * @param string $moduleName
+     * @param string|null $installedVersion
+     *
+     * @return array{latestVersion: string|null, upToDate: bool|null}
+     */
+    private function getModuleUpdateState($moduleName, $installedVersion)
+    {
+        $unknown = ['latestVersion' => null, 'upToDate' => null];
+
+        if (empty($installedVersion) || !class_exists('PrestaShop\PrestaShop\Adapter\SymfonyContainer')) {
+            return $unknown;
+        }
+
+        try {
+            $container = \PrestaShop\PrestaShop\Adapter\SymfonyContainer::getInstance();
+
+            if ($container === null || !$container->has('PrestaShop\PrestaShop\Core\Module\ModuleRepository')) {
+                return $unknown;
+            }
+
+            $module = $container
+                ->get('PrestaShop\PrestaShop\Core\Module\ModuleRepository')
+                ->getModule($moduleName);
+
+            $latestVersion = $module->attributes->get('version_available');
+
+            if (empty($latestVersion)) {
+                // No published version known: canBeUpgraded() would compare
+                // against the version on disk and always answer false.
+                return $unknown;
+            }
+
+            return [
+                'latestVersion' => (string) $latestVersion,
+                'upToDate' => version_compare($installedVersion, (string) $latestVersion, '>='),
+            ];
+        } catch (\Exception $exception) {
+            $this->errorHandler->handle($exception, true);
+
+            return $unknown;
+        }
     }
 
     /**

--- a/src/Service/ApiHealthCheckService.php
+++ b/src/Service/ApiHealthCheckService.php
@@ -297,9 +297,13 @@ class ApiHealthCheckService
                 return $unknown;
             }
 
-            $module = $container
-                ->get('PrestaShop\PrestaShop\Core\Module\ModuleRepository')
-                ->getModule($moduleName);
+            $repo = $container->get('PrestaShop\PrestaShop\Core\Module\ModuleRepository');
+
+            if ($repo === null) {
+                return $unknown;
+            }
+
+            $module = $repo->getModule($moduleName);
 
             $latestVersion = $module->attributes->get('version_available');
 

--- a/src/Service/PsAccountsAdapterService.php
+++ b/src/Service/PsAccountsAdapterService.php
@@ -119,30 +119,30 @@ class PsAccountsAdapterService
     }
 
     /**
-     * Get the shop front URL as psAccounts knows it, or an empty string if
-     * psAccounts isn't ready. This is the URL registered against the account,
-     * which the dashboard compares to the one CloudSync synchronizes with.
+     * Get the shop front URL as psAccounts knows it, or null if psAccounts
+     * isn't ready. This is the URL registered against the account, which the
+     * dashboard compares to the one CloudSync synchronizes with.
      *
-     * @return string
+     * @return string|null
      */
     public function getShopUrl()
     {
         if (!$this->moduleHelper->isInstalledAndActive('ps_accounts') || !$this->psAccountModule) {
-            return '';
+            return null;
         }
 
         try {
             $shopProvider = $this->psAccountModule->getService('PrestaShop\Module\PsAccounts\Provider\ShopProvider');
             $shop = (array) $shopProvider->getCurrentShop();
 
-            return isset($shop['frontUrl']) ? (string) $shop['frontUrl'] : '';
+            return isset($shop['frontUrl']) ? (string) $shop['frontUrl'] : null;
         } catch (\Exception $e) {
             $this->errorHandler->handle(
                 new \PrestaShopException('Failed to get shop url from ps_account', 0, $e),
                 true
             );
 
-            return '';
+            return null;
         }
     }
 

--- a/src/Service/PsAccountsAdapterService.php
+++ b/src/Service/PsAccountsAdapterService.php
@@ -119,6 +119,34 @@ class PsAccountsAdapterService
     }
 
     /**
+     * Get the shop front URL as psAccounts knows it, or an empty string if
+     * psAccounts isn't ready. This is the URL registered against the account,
+     * which the dashboard compares to the one CloudSync synchronizes with.
+     *
+     * @return string
+     */
+    public function getShopUrl()
+    {
+        if (!$this->moduleHelper->isInstalledAndActive('ps_accounts') || !$this->psAccountModule) {
+            return '';
+        }
+
+        try {
+            $shopProvider = $this->psAccountModule->getService('PrestaShop\Module\PsAccounts\Provider\ShopProvider');
+            $shop = (array) $shopProvider->getCurrentShop();
+
+            return isset($shop['frontUrl']) ? (string) $shop['frontUrl'] : '';
+        } catch (\Exception $e) {
+            $this->errorHandler->handle(
+                new \PrestaShopException('Failed to get shop url from ps_account', 0, $e),
+                true
+            );
+
+            return '';
+        }
+    }
+
+    /**
      * Get refreshToken from psAccounts, or null if module is'nt ready
      *
      * @return string

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
     cssCodeSplit: false,
     assetsInlineLimit: 100 * 1024,
     minify: true,
+    cssMinify: true,
     rollupOptions: {
       input: path.resolve(__dirname, 'frontend/js/main.js'),
       output: {
@@ -79,6 +80,12 @@ export default defineConfig({
     },
   },
   css: {
+    // puik-theme ships `@media (max-width: var(--screen-xs))`, and var() is not
+    // valid in a media query. Without error recovery lightningcss aborts the
+    // whole CSS minification instead of leaving that one rule alone.
+    lightningcss: {
+      errorRecovery: true,
+    },
     preprocessorOptions: {
       scss: {
         additionalData: `


### PR DESCRIPTION
Builds the dashboard page on top of the admin frontend base code (#477).

<img width="1397" height="1256" alt="image" src="https://github.com/user-attachments/assets/4fb46ca8-a3ba-439f-9cd7-067a54c04e47" />
