### PR TITLE
Fix reserved keyword `offset` in upgrade script

### DIFF
--- a/sql/tools/clean_incremental_sync.sql
+++ b/sql/tools/clean_incremental_sync.sql
@@ -17,7 +17,7 @@ AND table_name LIKE '%_eventbus_type_sync');
 -- enable full-sync for selected shop content
 SET @enable_full_sync = CONCAT('
 	UPDATE ', @eventbus_type_sync_table, '
-	SET `offset` = 0, full_sync_finished = 0
+	SET `last_seek_key` = NULL, full_sync_finished = 0
 	WHERE type IN (
 		SELECT type
 		FROM (

--- a/upgrade/Upgrade-4.1.0.php
+++ b/upgrade/Upgrade-4.1.0.php
@@ -40,7 +40,7 @@ function upgrade_module_4_1_0()
 
     $db->execute(
         'ALTER TABLE `' . _DB_PREFIX_ . 'eventbus_type_sync`
-          ADD COLUMN `last_seek_key` VARCHAR(190) DEFAULT NULL
+          ADD COLUMN `last_seek_key` VARCHAR(190) DEFAULT NULL,
           DROP COLUMN `offset`'
     );
 


### PR DESCRIPTION
## Summary
- Fix missing comma in `ALTER TABLE` statement in `Upgrade-4.1.0.php` that caused the migration from `offset` to `last_seek_key` to fail silently
- Update `sql/tools/clean_incremental_sync.sql` to reference `last_seek_key` instead of the removed `offset` column

Closes #447