### PR TITLE
fix: order full-sync count times out on large shops

### DIFF
--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -54,6 +54,12 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
             ->leftJoin('address', 'ai', 'ai.id_address = o.id_address_invoice')
             ->leftJoin('country', 'cntd', 'cntd.id_country = ad.id_country')
             ->leftJoin('country', 'cnti', 'cnti.id_country = ai.id_country')
+            // FIXME: join is not filtered by language ($langIso is ignored here).
+            // order_state_lang has one row per installed language, so on multi-lang
+            // shops this fans out; combined with the 1:n order_slip join it multiplies
+            // the refund SUM by the language count and makes status_label arbitrary.
+            // Fix: "AND osl.id_lang = <id from $langIso>" (per-language sync, like the
+            // other *_lang joins), collapsing osl to one row.
             ->leftJoin('order_state_lang', 'osl', 'o.current_state = osl.id_order_state')
             ->leftJoin('order_state', 'ost', 'o.current_state = ost.id_order_state')
             ->where('o.id_shop = ' . (int) parent::getShopContext()->id)

--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -176,16 +176,22 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
      */
     public function countFullSyncContentLeft($lastSeekKey, $langIso)
     {
-        $this->generateFullQuery($langIso, true);
+        // full query only LEFT-joins and filters on o.*, grouping by the PK, so
+        // none of its joins/aggregates change the set of counted orders. Count
+        // the table directly (id_shop index + PK) instead of materializing the
+        // joins and per-row aggregates for every remaining order.
+        $this->generateMinimalQuery(self::TABLE_NAME, 'o');
+
+        $this->query
+            ->select('COUNT(*) AS count')
+            ->where('o.id_shop = ' . (int) parent::getShopContext()->id)
+        ;
 
         if ($lastSeekKey !== null) {
             $this->query->where('o.id_order > ' . (int) $lastSeekKey);
         }
 
-        $result = $this->db->executeS('
-            SELECT COUNT(*) AS count
-                FROM (' . $this->query->build() . ') as subquery;
-        ');
+        $result = $this->db->executeS($this->query->build());
 
         return is_array($result) && isset($result[0]['count']) ? (int) $result[0]['count'] : 0;
     }


### PR DESCRIPTION
## Problem

A production shop with many orders fails to upload order data, hitting the 300s timeout **even with `limit=1`**.

Each full-sync batch (`SynchronizationService`) runs two queries:

1. **fetch** — `retrieveContentsForFull` → seek cursor + `LIMIT` → fast, unaffected by dataset size.
2. **count** — `countFullSyncContentLeft` → **no limit**, counts everything left.

The count is the bottleneck. `OrderRepository::countFullSyncContentLeft` wrapped `COUNT(*)` around the **full** SELECT query:

```sql
SELECT COUNT(*) FROM ( <full order query> ) AS subquery
```

To count, MySQL must materialize the whole remaining result set through:
- 8 joins + `GROUP BY o.id_order`,
- a **per-row correlated subquery** `new_customer` — `(SELECT ... FROM orders so WHERE so.id_customer = o.id_customer AND so.id_order < o.id_order LIMIT 1)`, run once per order,
- `SUM()` refund aggregates.

On a large shop the count alone blows past 300s. `limit=1` doesn't help — it bounds only the fetch, never the count.

## Fix

The count doesn't need any of that structure. Every join in the full query is a `LEFT` join (never drops an order) and the `WHERE` filters only on `o.id_shop` / `o.id_order`, so with `GROUP BY o.id_order` the count is exactly the number of orders matching the `WHERE`. Replace the wrapped full query with a direct count:

```sql
SELECT COUNT(*) FROM ps_orders o WHERE o.id_shop = ? AND o.id_order > ?
```

Served by the `(id_shop, id_order)` index — no joins, no grouping, no correlated subquery, no materialization. This is a structural complexity reduction, not just dropping the per-row subquery.

## Scope

Only `OrderRepository`. `CarrierDetailRepository` and `CarrierTaxeRepository` also count over their full query, but their `GROUP BY` references SELECT aliases (`id_range`, `country_id`) that exist only in the full query, and their result sets are bounded by carriers × zones, so they never approach the timeout. Left unchanged.

## Test plan

- [ ] Full-sync orders on a large-order shop completes under the timeout with `limit=1`.
- [ ] `remaining_objects` in the sync response matches the number of orders left to sync (identical to the previous count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)