### PR TITLE
fix: store datetimes in MySQL format to support strict sql_mode

### DIFF
--- a/src/Helper/DateHelper.php
+++ b/src/Helper/DateHelper.php
@@ -1,28 +1,4 @@
 <?php
-/**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- */
 
 namespace PrestaShop\Module\PsEventbus\Helper;
 

--- a/src/Helper/DateHelper.php
+++ b/src/Helper/DateHelper.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\Module\PsEventbus\Helper;
+
+use PrestaShop\Module\PsEventbus\Config\Config;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class DateHelper
+{
+    /**
+     * Normalizes any date representation into the format expected by our
+     * `DATETIME` columns.
+     *
+     * MySQL only tolerates ISO 8601 values such as `2026-08-13T11:26:59+02:00`
+     * when the server runs in a permissive `sql_mode`: it silently truncates
+     * them and raises a warning. With `STRICT_TRANS_TABLES` enabled (the
+     * default since MySQL 5.7) the very same insert fails with
+     * "Incorrect datetime value", so every date must be normalized before it
+     * reaches a query.
+     *
+     * The wall clock of the incoming value is preserved as-is: no timezone
+     * conversion happens, only a reformat.
+     *
+     * @param string|null $date
+     *
+     * @return string date formatted as `Y-m-d H:i:s`, current date when the
+     *                given value cannot be used
+     */
+    public static function toMySqlDateTime($date)
+    {
+        if (!is_string($date) || trim($date) === '') {
+            return date(Config::MYSQL_DATE_FORMAT);
+        }
+
+        try {
+            $dateTime = new \DateTime($date);
+        } catch (\Exception $exception) {
+            return date(Config::MYSQL_DATE_FORMAT);
+        }
+
+        // zero dates ('0000-00-00 00:00:00') are parsed by \DateTime but stay
+        // out of the range MySQL accepts in strict mode
+        if ((int) $dateTime->format('Y') < 1000) {
+            return date(Config::MYSQL_DATE_FORMAT);
+        }
+
+        return $dateTime->format(Config::MYSQL_DATE_FORMAT);
+    }
+}

--- a/src/Helper/DateHelper.php
+++ b/src/Helper/DateHelper.php
@@ -35,14 +35,16 @@ class DateHelper
             return date(Config::MYSQL_DATE_FORMAT);
         }
 
-        try {
-            $dateTime = new \DateTime($date);
-        } catch (\Exception $exception) {
+        // date_create() returns false on an unparseable string where the
+        // \DateTime constructor throws, which keeps this helper exception-free
+        $dateTime = date_create($date);
+
+        if ($dateTime === false) {
             return date(Config::MYSQL_DATE_FORMAT);
         }
 
-        // zero dates ('0000-00-00 00:00:00') are parsed by \DateTime but stay
-        // out of the range MySQL accepts in strict mode
+        // zero dates ('0000-00-00 00:00:00') are parsed but stay out of the
+        // range MySQL accepts in strict mode
         if ((int) $dateTime->format('Y') < 1000) {
             return date(Config::MYSQL_DATE_FORMAT);
         }

--- a/src/Repository/IncrementalSyncRepository.php
+++ b/src/Repository/IncrementalSyncRepository.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\Module\PsEventbus\Repository;
 
 use PrestaShop\Module\PsEventbus\Handler\ErrorHandler\ErrorHandler;
+use PrestaShop\Module\PsEventbus\Helper\DateHelper;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -68,8 +69,7 @@ class IncrementalSyncRepository extends AbstractRepository
             $query = 'INSERT INTO `' . _DB_PREFIX_ . self::TABLE_NAME . '` (type, id_object, id_shop, lang_iso, action, created_at) VALUES ';
 
             foreach ($arrayOfData as $currenData) {
-                $dateTime = new \DateTime($currenData['created_at']);
-                $date = $dateTime->format('Y-m-d H:i:s');
+                $date = DateHelper::toMySqlDateTime($currenData['created_at']);
 
                 $query .= "(
                     '{$this->db->escape($currenData['type'])}',

--- a/src/Repository/LiveSyncRepository.php
+++ b/src/Repository/LiveSyncRepository.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\Module\PsEventbus\Repository;
 
+use PrestaShop\Module\PsEventbus\Helper\DateHelper;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -78,10 +80,12 @@ class LiveSyncRepository
      */
     public function upsertDebounce($shopContent, $lastChangeAt)
     {
+        $lastChangeAt = pSQL(DateHelper::toMySqlDateTime($lastChangeAt));
+
         $query = '
             INSERT INTO `' . _DB_PREFIX_ . 'eventbus_live_sync` (`shop_content`, `last_change_at`)
-            VALUES ("' . pSQL($shopContent) . '", "' . pSQL($lastChangeAt) . '")
-            ON DUPLICATE KEY UPDATE `last_change_at` = "' . pSQL($lastChangeAt) . '";
+            VALUES ("' . pSQL($shopContent) . '", "' . $lastChangeAt . '")
+            ON DUPLICATE KEY UPDATE `last_change_at` = "' . $lastChangeAt . '";
         ';
 
         return $this->db->execute($query);

--- a/src/Repository/SyncRepository.php
+++ b/src/Repository/SyncRepository.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShop\Module\PsEventbus\Repository;
 
+use PrestaShop\Module\PsEventbus\Helper\DateHelper;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -54,7 +56,7 @@ class SyncRepository extends AbstractRepository
                 'id_shop' => parent::getShopContext()->id,
                 'lang_iso' => pSQL((string) $langIso),
                 'full_sync_finished' => (int) $fullSyncFinished,
-                'last_sync_date' => pSQL($date),
+                'last_sync_date' => pSQL(DateHelper::toMySqlDateTime($date)),
             ],
             false,
             true,
@@ -102,7 +104,7 @@ class SyncRepository extends AbstractRepository
             self::JOB_TABLE_NAME,
             [
                 'job_id' => pSQL($jobId),
-                'created_at' => pSQL($date),
+                'created_at' => pSQL(DateHelper::toMySqlDateTime($date)),
             ]
         );
     }

--- a/src/Service/ApiAuthorizationService.php
+++ b/src/Service/ApiAuthorizationService.php
@@ -28,6 +28,7 @@
 namespace PrestaShop\Module\PsEventbus\Service;
 
 use PrestaShop\Module\PsEventbus\Api\CloudSyncClient;
+use PrestaShop\Module\PsEventbus\Config\Config;
 use PrestaShop\Module\PsEventbus\Exception\EnvVarException;
 use PrestaShop\Module\PsEventbus\Exception\FirebaseException;
 use PrestaShop\Module\PsEventbus\Handler\ErrorHandler\ErrorHandler;
@@ -133,6 +134,6 @@ class ApiAuthorizationService
         $jobValidationResponse = $this->cloudSyncClient->validateJobId($jobId);
 
         return (int) $jobValidationResponse['httpCode'] === 201
-            && $this->syncRepository->insertJob($jobId, date(DATE_ATOM));
+            && $this->syncRepository->insertJob($jobId, date(Config::MYSQL_DATE_FORMAT));
     }
 }

--- a/src/Traits/Hooks/UseCarrierHooks.php
+++ b/src/Traits/Hooks/UseCarrierHooks.php
@@ -65,7 +65,7 @@ trait UseCarrierHooks
                     Config::COLLECTION_CARRIER_TAXES => $carrier->id,
                 ],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -102,7 +102,7 @@ trait UseCarrierHooks
                     Config::COLLECTION_CARRIER_TAXES => $carrier->id,
                 ],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -127,7 +127,7 @@ trait UseCarrierHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CARRIERS => $carrier->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseCartHooks.php
+++ b/src/Traits/Hooks/UseCartHooks.php
@@ -62,7 +62,7 @@ trait UseCartHooks
                     Config::COLLECTION_CART_PRODUCTS => $cart->id,
                 ],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -96,7 +96,7 @@ trait UseCartHooks
                     Config::COLLECTION_CART_PRODUCTS => $cart->id,
                 ],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );

--- a/src/Traits/Hooks/UseCartRuleHooks.php
+++ b/src/Traits/Hooks/UseCartRuleHooks.php
@@ -52,7 +52,7 @@ trait UseCartRuleHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CART_RULES => $cartRule->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -76,7 +76,7 @@ trait UseCartRuleHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CART_RULES => $cartRule->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -100,7 +100,7 @@ trait UseCartRuleHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CART_RULES => $cartRule->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseCategoryHooks.php
+++ b/src/Traits/Hooks/UseCategoryHooks.php
@@ -53,7 +53,7 @@ trait UseCategoryHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CATEGORIES => $category->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -78,7 +78,7 @@ trait UseCategoryHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CATEGORIES => $category->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -103,7 +103,7 @@ trait UseCategoryHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CATEGORIES => $category->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseCombinationHooks.php
+++ b/src/Traits/Hooks/UseCombinationHooks.php
@@ -77,7 +77,7 @@ trait UseCombinationHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_PRODUCTS => $uniqueProductId],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -138,7 +138,7 @@ trait UseCombinationHooks
         $synchronizationService->insertContentIntoIncremental(
             $incrementalSyncItems,
             Config::INCREMENTAL_TYPE_UPSERT,
-            date(DATE_ATOM),
+            date(Config::MYSQL_DATE_FORMAT),
             $this->shopId,
             true
         );
@@ -146,7 +146,7 @@ trait UseCombinationHooks
         $synchronizationService->insertContentIntoIncremental(
             [Config::COLLECTION_PRODUCTS => $combination->id_product],
             Config::INCREMENTAL_TYPE_DELETE,
-            date(DATE_ATOM),
+            date(Config::MYSQL_DATE_FORMAT),
             $this->shopId,
             true
         );

--- a/src/Traits/Hooks/UseCurrencyHooks.php
+++ b/src/Traits/Hooks/UseCurrencyHooks.php
@@ -53,7 +53,7 @@ trait UseCurrencyHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CURRENCIES => $currency->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -78,7 +78,7 @@ trait UseCurrencyHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CURRENCIES => $currency->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -103,7 +103,7 @@ trait UseCurrencyHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CURRENCIES => $currency->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseCustomerHooks.php
+++ b/src/Traits/Hooks/UseCustomerHooks.php
@@ -55,7 +55,7 @@ trait UseCustomerHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CUSTOMERS => $customer->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -81,7 +81,7 @@ trait UseCustomerHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CUSTOMERS => $customer->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -107,7 +107,7 @@ trait UseCustomerHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CUSTOMERS => $customer->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseEmployeeHooks.php
+++ b/src/Traits/Hooks/UseEmployeeHooks.php
@@ -55,7 +55,7 @@ trait UseEmployeeHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_EMPLOYEES => $employee->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -81,7 +81,7 @@ trait UseEmployeeHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_EMPLOYEES => $employee->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -107,7 +107,7 @@ trait UseEmployeeHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_EMPLOYEES => $employee->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseImageHooks.php
+++ b/src/Traits/Hooks/UseImageHooks.php
@@ -55,7 +55,7 @@ trait UseImageHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_IMAGES => $image->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -81,7 +81,7 @@ trait UseImageHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_IMAGES => $image->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -107,7 +107,7 @@ trait UseImageHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_IMAGES => $image->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );

--- a/src/Traits/Hooks/UseImageTypeHooks.php
+++ b/src/Traits/Hooks/UseImageTypeHooks.php
@@ -55,7 +55,7 @@ trait UseImageTypeHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_IMAGE_TYPES => $imageType->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -81,7 +81,7 @@ trait UseImageTypeHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_IMAGE_TYPES => $imageType->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -107,7 +107,7 @@ trait UseImageTypeHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_IMAGE_TYPES => $imageType->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );

--- a/src/Traits/Hooks/UseLanguageHooks.php
+++ b/src/Traits/Hooks/UseLanguageHooks.php
@@ -55,7 +55,7 @@ trait UseLanguageHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_LANGUAGES => $language->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -81,7 +81,7 @@ trait UseLanguageHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_LANGUAGES => $language->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -107,7 +107,7 @@ trait UseLanguageHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_LANGUAGES => $language->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseManufacturerHooks.php
+++ b/src/Traits/Hooks/UseManufacturerHooks.php
@@ -53,7 +53,7 @@ trait UseManufacturerHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_MANUFACTURERS => $manufacturer->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -78,7 +78,7 @@ trait UseManufacturerHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_MANUFACTURERS => $manufacturer->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -103,7 +103,7 @@ trait UseManufacturerHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_MANUFACTURERS => $manufacturer->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseOrderCarrierHooks.php
+++ b/src/Traits/Hooks/UseOrderCarrierHooks.php
@@ -53,7 +53,7 @@ trait UseOrderCarrierHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDER_CARRIERS => $orderCarrier->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -78,7 +78,7 @@ trait UseOrderCarrierHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDER_CARRIERS => $orderCarrier->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseOrderCartRuleHooks.php
+++ b/src/Traits/Hooks/UseOrderCartRuleHooks.php
@@ -53,7 +53,7 @@ trait UseOrderCartRuleHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDER_CART_RULES => $orderCartRule->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -78,7 +78,7 @@ trait UseOrderCartRuleHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDER_CART_RULES => $orderCartRule->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseOrderDetailHooks.php
+++ b/src/Traits/Hooks/UseOrderDetailHooks.php
@@ -53,7 +53,7 @@ trait UseOrderDetailHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDER_DETAILS => $orderDetail->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -78,7 +78,7 @@ trait UseOrderDetailHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDER_DETAILS => $orderDetail->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseOrderHistoryHooks.php
+++ b/src/Traits/Hooks/UseOrderHistoryHooks.php
@@ -53,7 +53,7 @@ trait UseOrderHistoryHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDER_STATUS_HISTORY => $orderHistory->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -78,7 +78,7 @@ trait UseOrderHistoryHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDER_STATUS_HISTORY => $orderHistory->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseOrderHooks.php
+++ b/src/Traits/Hooks/UseOrderHooks.php
@@ -53,7 +53,7 @@ trait UseOrderHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDERS => $order->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -78,7 +78,7 @@ trait UseOrderHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_ORDERS => $order->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseProductHooks.php
+++ b/src/Traits/Hooks/UseProductHooks.php
@@ -81,7 +81,7 @@ trait UseProductHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_PRODUCTS => $product->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -158,7 +158,7 @@ trait UseProductHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_CUSTOM_PRODUCT_CARRIERS => $productCarrierIds],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -166,7 +166,7 @@ trait UseProductHooks
             $synchronizationService->insertContentIntoIncremental(
                 $incrementalSyncItems,
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -178,7 +178,7 @@ trait UseProductHooks
                 $synchronizationService->insertContentIntoIncremental(
                     [Config::COLLECTION_CUSTOM_PRODUCT_CARRIERS => $customProductCarrierIds],
                     Config::INCREMENTAL_TYPE_DELETE,
-                    date(DATE_ATOM),
+                    date(Config::MYSQL_DATE_FORMAT),
                     $this->shopId,
                     true
                 );
@@ -188,7 +188,7 @@ trait UseProductHooks
                 $synchronizationService->insertContentIntoIncremental(
                     $incrementalSyncItems,
                     Config::INCREMENTAL_TYPE_UPSERT,
-                    date(DATE_ATOM),
+                    date(Config::MYSQL_DATE_FORMAT),
                     $this->shopId,
                     true
                 );

--- a/src/Traits/Hooks/UseSpecificPriceHooks.php
+++ b/src/Traits/Hooks/UseSpecificPriceHooks.php
@@ -53,7 +53,7 @@ trait UseSpecificPriceHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_SPECIFIC_PRICES => $specificPrice->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -78,7 +78,7 @@ trait UseSpecificPriceHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_SPECIFIC_PRICES => $specificPrice->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );
@@ -103,7 +103,7 @@ trait UseSpecificPriceHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_SPECIFIC_PRICES => $specificPrice->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseStockHooks.php
+++ b/src/Traits/Hooks/UseStockHooks.php
@@ -53,7 +53,7 @@ trait UseStockHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_STOCKS => $stockAvailable->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -78,7 +78,7 @@ trait UseStockHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_STOCKS => $stockAvailable->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );

--- a/src/Traits/Hooks/UseStoreHooks.php
+++ b/src/Traits/Hooks/UseStoreHooks.php
@@ -55,7 +55,7 @@ trait UseStoreHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_STORES => $store->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -81,7 +81,7 @@ trait UseStoreHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_STORES => $store->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -107,7 +107,7 @@ trait UseStoreHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_STORES => $store->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseSupplierHooks.php
+++ b/src/Traits/Hooks/UseSupplierHooks.php
@@ -53,7 +53,7 @@ trait UseSupplierHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_SUPPLIERS => $supplier->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -78,7 +78,7 @@ trait UseSupplierHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_SUPPLIERS => $supplier->id],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -103,7 +103,7 @@ trait UseSupplierHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_SUPPLIERS => $supplier->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/src/Traits/Hooks/UseWishlistHooks.php
+++ b/src/Traits/Hooks/UseWishlistHooks.php
@@ -62,7 +62,7 @@ trait UseWishlistHooks
                     Config::COLLECTION_WISHLIST_PRODUCTS => $wishlist->id,
                 ],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -95,7 +95,7 @@ trait UseWishlistHooks
                     Config::COLLECTION_WISHLIST_PRODUCTS => $wishlist->id,
                 ],
                 Config::INCREMENTAL_TYPE_UPSERT,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 true
             );
@@ -119,7 +119,7 @@ trait UseWishlistHooks
             $synchronizationService->insertContentIntoIncremental(
                 [Config::COLLECTION_WISHLISTS => $wishlist->id],
                 Config::INCREMENTAL_TYPE_DELETE,
-                date(DATE_ATOM),
+                date(Config::MYSQL_DATE_FORMAT),
                 $this->shopId,
                 false
             );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', getenv('PS_VERSION') ?: '8.1.6');
+}
+
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit bootstrap="../vendor/autoload.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" colors="true" executionOrder="random" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit bootstrap="bootstrap.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" colors="true" executionOrder="random" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Ps eventbus Tests">
       <directory>unit</directory>

--- a/tests/unit/Helper/DateHelperTest.php
+++ b/tests/unit/Helper/DateHelperTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace PrestaShop\Module\PsEventbus\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\PsEventbus\Helper\DateHelper;
+
+class DateHelperTest extends TestCase
+{
+    public function testConvertsIso8601ToMysqlDateTime()
+    {
+        $this->assertSame(
+            '2026-08-13 11:26:59',
+            DateHelper::toMySqlDateTime('2026-08-13T11:26:59+02:00')
+        );
+    }
+
+    public function testKeepsTheWallClockOfTheProvidedOffset()
+    {
+        $this->assertSame(
+            '2026-08-13 11:26:59',
+            DateHelper::toMySqlDateTime('2026-08-13T11:26:59-07:00')
+        );
+    }
+
+    public function testLeavesAnAlreadyValidMysqlDateTimeUntouched()
+    {
+        $this->assertSame(
+            '2026-08-13 11:26:59',
+            DateHelper::toMySqlDateTime('2026-08-13 11:26:59')
+        );
+    }
+
+    public function testCompletesADateWithoutTime()
+    {
+        $this->assertSame(
+            '2026-08-13 00:00:00',
+            DateHelper::toMySqlDateTime('2026-08-13')
+        );
+    }
+
+    /**
+     * @dataProvider provideUnusableDates
+     *
+     * @param mixed $date
+     *
+     * @return void
+     */
+    public function testFallsBackToNowOnUnusableDates($date)
+    {
+        $before = date('Y-m-d H:i:s', time() - 1);
+        $normalized = DateHelper::toMySqlDateTime($date);
+        $after = date('Y-m-d H:i:s', time() + 1);
+
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+            $normalized
+        );
+        $this->assertGreaterThanOrEqual($before, $normalized);
+        $this->assertLessThanOrEqual($after, $normalized);
+    }
+
+    /**
+     * @return array<string, array<mixed>>
+     */
+    public static function provideUnusableDates()
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+            'zero date' => ['0000-00-00 00:00:00'],
+            'garbage' => ['not-a-date'],
+        ];
+    }
+}

--- a/upgrade/Upgrade-4.1.1.php
+++ b/upgrade/Upgrade-4.1.1.php
@@ -23,42 +23,41 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-namespace PrestaShop\Module\PsEventbus\Traits\Hooks;
-
-use PrestaShop\Module\PsEventbus\Config\Config;
-use PrestaShop\Module\PsEventbus\Service\SynchronizationService;
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-trait UseStockMvtHooks
+/**
+ * Repairs the `DATETIME` columns that could have been filled with an ISO 8601
+ * value before the module started normalizing dates.
+ *
+ * On a permissive `sql_mode` MySQL truncated `2026-08-13T11:26:59+02:00` to a
+ * valid datetime and only raised a warning, but depending on the server the
+ * same insert could also land as a zero date, which then breaks every read
+ * that hydrates a \DateTime from it.
+ *
+ * @return bool
+ */
+function upgrade_module_4_1_1()
 {
-    /**
-     * Work Only on 1.6
-     *
-     * @param array<mixed> $parameters
-     *
-     * @return void
-     */
-    public function hookActionObjectStockMvtAddAfter($parameters)
-    {
-        /** @var SynchronizationService $synchronizationService * */
-        $synchronizationService = $this->getService(Config::SYNC_SERVICE_NAME);
+    $db = Db::getInstance();
 
-        /** @var \StockMvt $stockMvt */
-        $stockMvt = $parameters['object'];
+    $tables = [
+        'eventbus_job' => 'created_at',
+        'eventbus_incremental_sync' => 'created_at',
+        'eventbus_type_sync' => 'last_sync_date',
+        'eventbus_live_sync' => 'last_change_at',
+    ];
 
-        if (isset($stockMvt->id)) {
-            $synchronizationService->sendLiveSync(Config::COLLECTION_STOCK_MOVEMENTS, Config::INCREMENTAL_TYPE_UPSERT);
-            $synchronizationService->insertContentIntoIncremental(
-                [Config::COLLECTION_STOCK_MOVEMENTS => $stockMvt->id],
-                Config::INCREMENTAL_TYPE_UPSERT,
-                date(Config::MYSQL_DATE_FORMAT),
-                $this->shopId,
-                true
-            );
-        }
+    foreach ($tables as $table => $column) {
+        // a zero date cannot be compared with a literal in strict mode, hence YEAR()
+        $db->execute(
+            'UPDATE `' . _DB_PREFIX_ . $table . '`
+              SET `' . $column . '` = NOW()
+              WHERE `' . $column . '` IS NULL
+                 OR YEAR(`' . $column . '`) < 1000'
+        );
     }
+
+    return true;
 }

--- a/upgrade/Upgrade-4.1.1.php
+++ b/upgrade/Upgrade-4.1.1.php
@@ -1,28 +1,5 @@
 <?php
-/**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- */
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }


### PR DESCRIPTION
## Problem

On a shop running MySQL with `STRICT_TRANS_TABLES`, every CloudSync call fails:

```
Incorrect datetime value: '2026-08-13T11:26:59+02:00' for column `_eventbus_job`.`created_at` at row 1
INSERT INTO `_eventbus_job` (`job_id`, `created_at`)
VALUES ('3ef50e0ab...', '2026-08-13T11:26:59+02:00')
```

`ApiAuthorizationService::authorizeCall()` built the date with `date(DATE_ATOM)`, i.e. ISO 8601 with a timezone offset, and passed it straight to a `DATETIME` column.

Why it only breaks on some shops: with a permissive `sql_mode`, MySQL truncates the value to `2026-08-13 11:26:59` and only raises a warning. With `STRICT_TRANS_TABLES` — the default since MySQL 5.7 — it refuses the value and throws, so `authorize()` fails and `handleDataSync` dies on a `PrestaShopDatabaseException`.

## Fix

- New `Helper\DateHelper::toMySqlDateTime()`: normalizes any date representation to `Y-m-d H:i:s`, preserving the wall clock (no timezone conversion), and falls back to the current date for `null` / empty / zero / unparseable values.
- Called by every repository writing a date: `SyncRepository` (`created_at`, `last_sync_date`), `LiveSyncRepository` (`last_change_at`) and `IncrementalSyncRepository` (`created_at`, which already did the conversion inline — now centralized). A badly formatted date can no longer reach a query, whatever the caller does.
- `ApiAuthorizationService` and the 24 hook traits now use `Config::MYSQL_DATE_FORMAT` instead of `DATE_ATOM`. These dates are only ever consumed by our own `DATETIME` columns, never sent over the wire, so this is a pure format change.

## Upgrade script

`upgrade/Upgrade-4.1.1.php` resets to `NOW()` any `NULL` or zero date left in `eventbus_job`, `eventbus_incremental_sync`, `eventbus_type_sync` and `eventbus_live_sync`, so rows written before the fix cannot break the reads that hydrate a `\DateTime` from them.