### PR TITLE
fix: order full-sync times out on shops with >1M orders

### DIFF
--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -136,15 +136,66 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
      */
     public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
+        // Two-step (deferred join) pagination.
+        //
+        // The full query LEFT-joins 8 tables, aggregates (SUM over order_slip)
+        // and runs a correlated subquery (new_customer) per row. If we paginate
+        // it directly with "id_order > seek ... LIMIT n", the optimizer sees a
+        // range estimate of ~all orders in the shop and can pick a plan with
+        // "Using filesort"/temp table that materializes the whole range BEFORE
+        // applying LIMIT. Cost then scales with total orders, not the page size,
+        // so even limit=1 times out on shops with >1M orders.
+        //
+        // Instead: first pick the page's ids with a bare, covering index range
+        // scan (id_shop index = (id_shop, id_order)) that LIMIT bounds to n rows,
+        // then run the heavy query filtered on those ids. The joins/aggregate/
+        // subquery then run for exactly n rows whatever plan the optimizer picks.
+        $pageIds = $this->getFullSyncPageIds($lastSeekKey, (int) $limit);
+
+        if (empty($pageIds)) {
+            return [];
+        }
+
         $this->generateFullQuery($langIso, true);
+
+        $this->query->where('o.id_order IN (' . implode(',', $pageIds) . ')');
+
+        return $this->runQuery();
+    }
+
+    /**
+     * Bare, covering index range scan to select the next page of order ids.
+     *
+     * @param string|null $lastSeekKey
+     * @param int $limit
+     *
+     * @return array<int>
+     *
+     * @throws \PrestaShopException
+     * @throws \PrestaShopDatabaseException
+     */
+    private function getFullSyncPageIds($lastSeekKey, $limit)
+    {
+        $this->generateMinimalQuery(self::TABLE_NAME, 'o');
+
+        $this->query
+            ->select('o.id_order')
+            ->where('o.id_shop = ' . (int) parent::getShopContext()->id)
+            ->orderBy('o.id_order ASC')
+            ->limit($limit)
+        ;
 
         if ($lastSeekKey !== null) {
             $this->query->where('o.id_order > ' . (int) $lastSeekKey);
         }
 
-        $this->query->limit((int) $limit);
+        $result = $this->db->executeS($this->query->build());
 
-        return $this->runQuery();
+        if (!is_array($result)) {
+            return [];
+        }
+
+        return array_map('intval', array_column($result, 'id_order'));
     }
 
     /**

--- a/src/Service/ShopContent/OrdersService.php
+++ b/src/Service/ShopContent/OrdersService.php
@@ -129,6 +129,13 @@ class OrdersService extends ShopContentAbstractService implements ShopContentSer
      */
     private function castOrders(&$orders, $langIso)
     {
+        // Compute the latest paid-state per order ONCE for the whole page.
+        // Previously castIsPaidValue() was called inside the loop below, and each
+        // call re-ran the full order_history JOIN for every id in the page: O(n)
+        // identical queries + O(n^2) PHP scan per page. On shops with >1M orders
+        // that blew the request timeout and full sync never progressed.
+        $isPaidByOrderId = $this->buildIsPaidMap($orders, $langIso);
+
         foreach ($orders as &$order) {
             $order['id_order'] = (int) $order['id_order'];
             $order['id_cart'] = (string) $order['id_cart'];
@@ -140,7 +147,9 @@ class OrdersService extends ShopContentAbstractService implements ShopContentSer
             $order['refund'] = (float) $order['refund'];
             $order['refund_tax_excl'] = (float) $order['refund_tax_excl'];
             $order['new_customer'] = $order['new_customer'] == 1;
-            $order['is_paid'] = $this->castIsPaidValue($orders, $order, $langIso);
+            $order['is_paid'] = isset($isPaidByOrderId[(int) $order['id_order']])
+                ? $isPaidByOrderId[(int) $order['id_order']]
+                : false;
             $order['shipping_cost'] = (float) $order['shipping_cost'];
             $order['total_paid_tax'] = $order['total_paid_tax_incl'] - $order['total_paid_tax_excl'];
             $order['id_carrier'] = (int) $order['id_carrier'];
@@ -181,29 +190,44 @@ class OrdersService extends ShopContentAbstractService implements ShopContentSer
     }
 
     /**
+     * Build a map id_order => is_paid for the whole page in a single query.
+     *
+     * is_paid reflects the most recent status in order_history (max date_add).
+     * Tie-break preserves the previous behavior: rows arrive ordered by
+     * id_order_history ASC and the first row reaching the max date wins.
+     *
      * @param array<mixed> $orders
-     * @param array<mixed> $order
      * @param string $langIso
      *
-     * @return bool
+     * @return array<int, bool>
      *
      * @@throws \PrestaShopDatabaseException
      */
-    private function castIsPaidValue($orders, $order, $langIso)
+    private function buildIsPaidMap($orders, $langIso)
     {
-        $isPaid = $dateAdd = 0;
         $orderIds = $this->arrayFormatter->formatValueArray($orders, 'id_order');
+
+        if (empty($orderIds)) {
+            return [];
+        }
+
         /** @var array<mixed> $orderStatusHistories */
         $orderStatusHistories = $this->orderStatusHistoryRepository->getOrderStatusHistoriesByOrderIds($orderIds, $langIso);
 
-        foreach ($orderStatusHistories as &$orderStatusHistory) {
-            if ($order['id_order'] == $orderStatusHistory['id_order'] && $dateAdd < $orderStatusHistory['date_add']) {
-                $isPaid = (bool) $orderStatusHistory['is_paid'];
-                $dateAdd = $orderStatusHistory['date_add'];
+        $isPaidByOrderId = [];
+        $latestDateByOrderId = [];
+
+        foreach ($orderStatusHistories as $history) {
+            $orderId = (int) $history['id_order'];
+            $dateAdd = $history['date_add'];
+
+            if (!isset($latestDateByOrderId[$orderId]) || $latestDateByOrderId[$orderId] < $dateAdd) {
+                $latestDateByOrderId[$orderId] = $dateAdd;
+                $isPaidByOrderId[$orderId] = (bool) $history['is_paid'];
             }
         }
 
-        return (bool) $isPaid;
+        return $isPaidByOrderId;
     }
 
     /**


### PR DESCRIPTION
## Problem

Order full sync stalls on shops with >1M orders — the SQL times out and orders never sync. The timeout is **independent of the request `limit`** (reproduced even at `limit=1`), which rules out per-page scaling and points at a query whose cost scales with total order count.

## Root cause (proven on a 1M-order e2e dataset)

`OrderRepository::retrieveContentsForFull` paginated the **full** query directly. That query LEFT-joins 8 tables, aggregates (`SUM` over `order_slip`) and runs a per-row correlated subquery (`new_customer`), then `GROUP BY id_order ORDER BY id_order LIMIT n`.

With `id_order > seek ... LIMIT n`, the optimizer sees a range estimate of ~all orders in the shop (~980k) and can pick a **`Using filesort` / temp-table** plan that materializes the whole range **before** applying `LIMIT`. Cost then scales with total orders, not page size.

Reproduced by forcing that plan (`SQL_BIG_RESULT`, i.e. what production MySQL can pick from the row estimate):

| query | plan | time (LIMIT 1, 1M orders) |
|-------|------|----------|
| flat, forced bad plan | `range` + `Using filesort`, rows≈980k | **1.57s** (grows with total) |
| deferred (this PR) | id-pick `Using index` + heavy `IN(n)` | **~0.09s** (flat in total count) |

Matches the `limit=1` batch-shrink observed in the in-module trace logs.

## Fixes

**1. Deferred-join pagination** (`OrderRepository::retrieveContentsForFull`)
Two steps: (a) pick the page's ids with a bare **covering index range scan** (`id_shop` index = `(id_shop, id_order)`), which `LIMIT` bounds to `n` rows; (b) run the heavy query filtered on `id_order IN (n ids)`. Joins/aggregate/subquery now run for exactly `n` rows under **any** optimizer plan. Verified output is **byte-identical** to the previous query (`diff` empty over a 1M-row page at deep seek).

**2. O(n²) `is_paid` lookup** (`OrdersService`)
`castOrders()` called `castIsPaidValue()` inside its per-order loop, and each call re-ran the full `order_history` JOIN for **every** id in the page plus an O(n) PHP scan → O(n) identical queries + O(n²) work per page. Replaced with `buildIsPaidMap()`: one query per page building an `id_order => is_paid` map. Tie-break behavior preserved (strict `<`, first max-date row wins). Benefits both full and incremental sync (shared `castOrders`).

## Verification
- Reproduced the timeout and the fix at SQL level on a seeded 1M-order + 200k-slip + 1M-history e2e dataset.
- Correctness diff old vs new page query: identical.
- `php -l` clean on both files.
- Not exercised: full PHP sync endpoint wall-clock end-to-end.

## Out of scope (follow-up)
`order_state_lang` join in `OrderRepository::generateFullQuery` is not language-filtered (existing `FIXME`) — on multi-lang shops it fans out and inflates the `refund` SUM by the language count. Correctness bug, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)