### PR TITLE
fix: order refund/status_label inflated on multi-lang shops

### DIFF
--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -44,6 +44,8 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
      */
     public function generateFullQuery($langIso, $withSelecParameters)
     {
+        $langId = (int) \Language::getIdByIso($langIso);
+
         $this->generateMinimalQuery(self::TABLE_NAME, 'o');
 
         // minimal query for countable query
@@ -54,13 +56,12 @@ class OrderRepository extends AbstractRepository implements RepositoryInterface
             ->leftJoin('address', 'ai', 'ai.id_address = o.id_address_invoice')
             ->leftJoin('country', 'cntd', 'cntd.id_country = ad.id_country')
             ->leftJoin('country', 'cnti', 'cnti.id_country = ai.id_country')
-            // FIXME: join is not filtered by language ($langIso is ignored here).
-            // order_state_lang has one row per installed language, so on multi-lang
-            // shops this fans out; combined with the 1:n order_slip join it multiplies
-            // the refund SUM by the language count and makes status_label arbitrary.
-            // Fix: "AND osl.id_lang = <id from $langIso>" (per-language sync, like the
-            // other *_lang joins), collapsing osl to one row.
-            ->leftJoin('order_state_lang', 'osl', 'o.current_state = osl.id_order_state')
+            // Filter order_state_lang by the synced language, like the other *_lang
+            // joins. order_state_lang has one row per installed language; without this
+            // filter the join fans out on multi-lang shops and, combined with the 1:n
+            // order_slip join, multiplies the refund SUM by the language count and
+            // makes status_label arbitrary.
+            ->leftJoin('order_state_lang', 'osl', 'o.current_state = osl.id_order_state AND osl.id_lang = ' . $langId)
             ->leftJoin('order_state', 'ost', 'o.current_state = ost.id_order_state')
             ->where('o.id_shop = ' . (int) parent::getShopContext()->id)
             ->select('o.id_order')


### PR DESCRIPTION
## Problem

In `OrderRepository::generateFullQuery`, the `order_state_lang` (`osl`) join is **not** filtered by language, unlike the other `*_lang` joins:

```php
->leftJoin('order_state_lang', 'osl', 'o.current_state = osl.id_order_state')
```

`order_state_lang` has one row per installed language, so on multi-lang shops the join returns one row per language. Combined with the 1:n `order_slip` join, the `GROUP BY o.id_order` then aggregates over the duplicated rows:

- `SUM(...) as refund` and `refund_tax_excl` are **multiplied by the number of languages**.
- `status_label` (`osl.name`) is picked **arbitrarily** from one language.

This silently corrupts synced order data on every multi-lang shop. (Documented as a `FIXME` in the code.)

## Fix

Filter the join on the synced language, matching the pattern already used in `OrderStatusHistoryRepository`:

```php
$langId = (int) \Language::getIdByIso($langIso);
...
->leftJoin('order_state_lang', 'osl', 'o.current_state = osl.id_order_state AND osl.id_lang = ' . $langId)
```

`$langIso` is resolved to the default language upstream (`ApiShopContentService`) when empty, so `$langId` is always valid. This collapses `osl` back to one row and leaves the `refund` SUM depending only on the `order_slip` rows.

## Verification (e2e, 2 languages, one refund of 132)

| | `refund` | `status_label` |
|---|---|---|
| before | **264** (×2 langs) | arbitrary language |
| after | **132** | deterministic (synced lang) |

`php -l` clean.

## Notes
Independent of #487 (performance/timeout). This branch is off `main` and touches only the join condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)