### PR TITLE
fix: seek-paginate cart_product full sync instead of OFFSET

### DIFF
--- a/src/Repository/CartProductRepository.php
+++ b/src/Repository/CartProductRepository.php
@@ -55,17 +55,23 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
                 ->select('cp.id_product_attribute')
                 ->select('cp.quantity')
                 ->select('cp.date_add as created_at')
-                ->orderBy('cp.id_cart ASC')
+                // Ordered by the (id_cart, id_product, id_product_attribute)
+                // triple, a prefix of the PK, so seek pages stay index-ordered.
+                ->orderBy('cp.id_cart ASC, cp.id_product ASC, cp.id_product_attribute ASC')
             ;
         }
     }
 
     /**
-     * Offset-based page. $lastSeekKey is the row count emitted so far.
-     * SQL LIMIT/OFFSET is stable because generateFullQuery adds
-     * ORDER BY cp.id_cart ASC.
+     * Seek-based page: returns rows strictly after the (id_cart, id_product,
+     * id_product_attribute) triple encoded in $lastSeekKey.
      *
-     * @param string|null $lastSeekKey row offset emitted so far
+     * Was offset-based (LIMIT n OFFSET k), which scans and discards k rows on
+     * every page: O(offset) cost that degrades to a timeout on shops with a
+     * large cart_product table (abandoned/guest carts). Seek on the PK-prefix
+     * triple instead so each page is an index range scan bounded to n rows.
+     *
+     * @param string|null $lastSeekKey "{id_cart}-{id_product}-{id_product_attribute}"
      * @param int $limit
      * @param string $langIso
      *
@@ -77,9 +83,50 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     public function retrieveContentsForFull($lastSeekKey, $limit, $langIso)
     {
         $this->generateFullQuery($langIso, true);
-        $this->query->limit((int) $limit, (int) $lastSeekKey);
+
+        if ($lastSeekKey !== null && $lastSeekKey !== '') {
+            $this->query->where($this->buildSeekWhere($lastSeekKey));
+        }
+
+        $this->query->limit((int) $limit);
 
         return $this->runQuery();
+    }
+
+    /**
+     * Explicit OR form of the composite-key comparison, kept so the PK prefix
+     * (id_cart, id_product, id_product_attribute) stays usable for the seek.
+     *
+     * @param string $lastSeekKey
+     *
+     * @return string
+     */
+    private function buildSeekWhere($lastSeekKey)
+    {
+        list($lastCart, $lastProduct, $lastAttribute) = $this->decodeTripleSeekKey($lastSeekKey);
+
+        return '('
+            . 'cp.id_cart > ' . $lastCart
+            . ' OR (cp.id_cart = ' . $lastCart . ' AND cp.id_product > ' . $lastProduct . ')'
+            . ' OR (cp.id_cart = ' . $lastCart . ' AND cp.id_product = ' . $lastProduct
+                . ' AND cp.id_product_attribute > ' . $lastAttribute . ')'
+            . ')';
+    }
+
+    /**
+     * @param string $seekKey "{id_cart}-{id_product}-{id_product_attribute}"
+     *
+     * @return array{0: int, 1: int, 2: int}
+     */
+    private function decodeTripleSeekKey($seekKey)
+    {
+        $parts = explode('-', $seekKey, 3);
+
+        return [
+            (int) $parts[0],
+            isset($parts[1]) ? (int) $parts[1] : 0,
+            isset($parts[2]) ? (int) $parts[2] : 0,
+        ];
     }
 
     /**
@@ -105,9 +152,9 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     }
 
     /**
-     * Remaining row count = total rows for this shop - offset already emitted.
+     * Count rows strictly after the seek-key triple.
      *
-     * @param string|null $lastSeekKey row offset emitted so far
+     * @param string|null $lastSeekKey "{id_cart}-{id_product}-{id_product_attribute}"
      * @param string $langIso
      *
      * @return int
@@ -119,12 +166,15 @@ class CartProductRepository extends AbstractRepository implements RepositoryInte
     {
         $shopId = (int) parent::getShopContext()->id;
 
-        $total = (int) $this->db->getValue('
+        $sql = '
             SELECT COUNT(*)
               FROM ' . _DB_PREFIX_ . self::TABLE_NAME . ' cp
-             WHERE cp.id_shop = ' . $shopId . '
-        ');
+             WHERE cp.id_shop = ' . $shopId;
 
-        return max(0, $total - (int) $lastSeekKey);
+        if ($lastSeekKey !== null && $lastSeekKey !== '') {
+            $sql .= ' AND ' . $this->buildSeekWhere($lastSeekKey);
+        }
+
+        return (int) $this->db->getValue($sql);
     }
 }

--- a/src/Service/ShopContent/CartProductsService.php
+++ b/src/Service/ShopContent/CartProductsService.php
@@ -54,10 +54,15 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
     {
         $result = $this->cartProductRepository->retrieveContentsForFull($lastSeekKey, $limit, $langIso);
 
-        $newSeekKey = (string) ((int) $lastSeekKey + count($result));
+        $newSeekKey = $lastSeekKey;
         $rows = [];
 
         if (!empty($result)) {
+            $lastRow = end($result);
+            $newSeekKey = ((int) $lastRow['id_cart'])
+                . '-' . ((int) $lastRow['id_product'])
+                . '-' . ((int) $lastRow['id_product_attribute']);
+
             $this->castCartProducts($result);
 
             $rows = array_map(function ($item) {
@@ -106,10 +111,11 @@ class CartProductsService extends ShopContentAbstractService implements ShopCont
     }
 
     /**
-     * Cursor is a row offset, not a content id — a numeric compare against
-     * id_cart would be misleading. Always record: over-recording during full
-     * sync is safe (incremental sync will re-upload extra rows), while under-
-     * recording could drop a mutation to an already-uploaded cart.
+     * The cursor is a composite "{id_cart}-{id_product}-{id_product_attribute}"
+     * triple while the outbox records mutations per id_cart, so the two are not
+     * directly comparable. Always record: over-recording during full sync is
+     * safe (incremental sync re-uploads the extra rows), while under-recording
+     * could drop a mutation to an already-uploaded cart.
      *
      * {@inheritdoc}
      */


### PR DESCRIPTION
## Problem

`CartProductRepository::retrieveContentsForFull` paginated with `LIMIT n OFFSET k`, and `CartProductsService` advanced the cursor as a cumulative row count:

```php
$this->query->limit((int) $limit, (int) $lastSeekKey);         // repo
$newSeekKey = (string) ((int) $lastSeekKey + count($result));  // service
```

`OFFSET k` makes MySQL scan and discard `k` rows on every page → **O(offset) per page, O(n²/limit) over a full sync**. `cart_product` is one of the largest tables on big shops (a row per line of every cart, including abandoned and guest carts), so deep pages progressively slow down and the full sync eventually times out — same failure family as the orders timeout, deep-page mechanism.

## Fix

Seek-paginate on the `(id_cart, id_product, id_product_attribute)` triple — a **prefix of the primary key** `(id_cart, id_product, id_product_attribute, id_customization, id_address_delivery)` — so each page is an index range scan bounded to `n` rows regardless of depth. The triple matches the emitted `id_cart_product` (`{id_cart}-{id_product}-{id_product_attribute}`), so collapse semantics are unchanged.

- `retrieveContentsForFull`: explicit OR-form seek predicate on the triple + plain `LIMIT` (kept explicit so the PK prefix stays usable).
- `countFullSyncContentLeft`: counts rows **after** the seek key instead of `total - offset`.
- `CartProductsService`: emits the triple of the last row as the new seek key; stale "cursor is a row offset" comment on `isAtOrBehindSeekKey` updated (still returns `true` — a safe over-recording superset).

## Verification (1M-row cart_product e2e)

- Deep page **~0.08s (seek)** vs a growing offset cost (**0.09s → 0.26s**); `EXPLAIN`: `PRIMARY` range, no filesort/temp, key_len 12.
- OR-form predicate ≡ row-value tuple comparison `(id_cart,id_product,id_product_attribute) > (a,b,c)` — same count (750002 = 750002).
- **Full seek walk covers all 1,000,007 rows across 21 pages with no gaps or duplicates.**

`php -l` clean on both files.

## Notes
Independent of #487/#488/#489. `retrieveContentsForIncremental` (`id_cart IN (...)`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)